### PR TITLE
Scene LoadのQueryとViewModelを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.13.0] - 2026-08-02
+### Add
+- 追跡中Sceneの名前、状態、優先度、進捗、Active判定を取得時点の不変値として返す公開`SceneLoadInfo`を追加した。`SceneLoader.GetSceneInfos()`で既知のScene名なしに一覧を取得でき、`TryGetSceneInfo`で1件を安全に照会できる。既存の`IsExist`と`TryGetState`は互換性を維持する。
+- `SceneLoadQuery`の点検索、一覧順、Active判定、スナップショット性と、`SceneLoadViewModel`の初期値、内容同値時の通知抑制、購読解除を検証するEditModeテストを追加した。
+
+### Change
+- Scene Loadの読み取り経路を内部`SceneLoadQuery`へ集約し、公開API向け`SceneLoadInfo`とView向け`SceneLoadDto`を分離した。`SceneLoader`はRegistry／Entityを直接読まず、状態照会をQueryへ転送する。
+- `SceneLoaderWindow`を`SceneLoadViewModel`の読み取り専用ReactiveProperty購読へ変更した。private fieldのリフレクションとEditor更新ごとのDictionary再取得を廃止し、状態変更時だけScene名、状態、優先度、進捗、Active判定を再描画する。Play Mode終了時には購読を解除するため、Domain Reload無効でも前回の表示状態を残さない。
+- `SymphonyMcpTools.GetSceneLoaderJson()`を公開`SceneLoadInfo`から生成するようにし、既存JSONフィールドを維持したまま`progress`と`isActive`を追加した。Scene Loader Sampleと利用者向け文書も新しい状態照会APIへ更新した。
+
 ## [2.12.0] - 2026-08-02
 ### Add
 - シーン名とActive Scene選択用の優先度を一体で扱う公開Value Object `SceneLoadRequest`を追加した。単一／複数ロード用の新しいoverloadへ渡せるため、複数シーンでもシーン名と優先度の対応を崩さず指定できる。

--- a/Documentation~/AgentUsage.md
+++ b/Documentation~/AgentUsage.md
@@ -38,6 +38,7 @@
 - シーン遷移は原則`SceneLoader`を使う。`SceneManager.LoadScene`を直接使うと、優先度管理、依存注入、`IInitializeAsync`が働かない。
 - `LoadSceneMode.Single`は対象をAdditiveでロードした後、他の追跡シーンをアンロードする。現在のシーンを残す場合は`Additive`を使う。
 - 依存注入または`IInitializeAsync`の失敗は`SceneInitializationException`。Build Settings未登録など通常のロード失敗はfalseで返る。
+- 追跡中のScene名が分からない状態で一覧を調べる場合は`SceneLoader.GetSceneInfos()`を使う。既知のScene名だけを調べる場合は`TryGetSceneInfo`を使い、戻る`SceneLoadInfo`を取得時点のスナップショットとして扱う。
 
 ## Save Data System
 

--- a/Documentation~/Architecture.md
+++ b/Documentation~/Architecture.md
@@ -92,11 +92,21 @@ classDiagram
         LoadScene()
         UnloadScene()
         SetActiveScene()
+        GetSceneInfos()
+        TryGetSceneInfo()
     }
     class SceneLoadRequest {
         <<readonly struct>>
         SceneName
         Priority
+    }
+    class SceneLoadInfo {
+        <<readonly struct>>
+        SceneName
+        State
+        Priority
+        Progress
+        IsActive
     }
     class IInitializeAsync {
         <<interface>>
@@ -139,6 +149,7 @@ classDiagram
     ServiceInjector ..> ServiceLocator : 登録済み依存を取得
     ServiceInjector --> IInjectable : 注入
     SceneLoader --> SceneLoadRequest : ロード対象と優先度
+    SceneLoader --> SceneLoadInfo : 追跡状態のスナップショット
     SceneLoader ..> ServiceInjector : ルートへ自動注入
     SceneLoader --> IInitializeAsync : 完了を待機
     SaveDataRegistry --> SaveDataContent : 型単位でキャッシュ
@@ -147,6 +158,22 @@ classDiagram
 ```
 
 Facadeは利用側の入口、interfaceと抽象classは利用側が実装する拡張点です。ConfigとManagerの内部実装はFacadeの背後に隠し、利用側へ公開しません。
+
+Scene Loadの内部では、Commandと読み取りを分離しています。
+
+```mermaid
+flowchart LR
+    Loader["SceneLoader"] -->|Command| Service["SceneLoadService"]
+    Service --> Registry["SceneLoadRegistry"]
+    Registry --> Entity["SceneLoadEntity"]
+    Loader -->|Query| Query["SceneLoadQuery"]
+    Query --> Registry
+    Query --> Info["SceneLoadInfo"]
+    Service -->|状態変更event| ViewModel["SceneLoadViewModel"]
+    ViewModel -->|ReactiveProperty| Window["SceneLoaderWindow"]
+```
+
+`SceneLoadQuery`だけがRegistry／Entityを読み取り、利用側には`SceneLoadInfo`、Viewには内部Dtoを返します。`SceneLoaderWindow`はViewModelを購読し、RuntimeのRegistryやEntityを直接参照しません。
 
 ## シーンロード時の連携
 

--- a/Editor/Administrator/SymphonyAdministrator.cs
+++ b/Editor/Administrator/SymphonyAdministrator.cs
@@ -26,7 +26,6 @@ namespace SymphonyFrameWork.Editor
         {
             _pauseWindow?.Update();
             _serviceLocatorWindow?.Update();
-            _sceneLoaderWindow?.Update();
             _saveDataRegistryWindow?.Update();
         }
 
@@ -55,7 +54,9 @@ namespace SymphonyFrameWork.Editor
         private void OnDisable()
         {
             EditorApplication.update -= Update;
+            _sceneLoaderWindow?.Dispose();
             _saveDataRegistryWindow?.Dispose();
+            _sceneLoaderWindow = null;
             _saveDataRegistryWindow = null;
         }
 

--- a/Editor/Administrator/UITK/CS/SceneLoaderWindow.cs
+++ b/Editor/Administrator/UITK/CS/SceneLoaderWindow.cs
@@ -1,24 +1,19 @@
-﻿using SymphonyFrameWork.Core;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 using SymphonyFrameWork.System.SceneLoad;
 using SymphonyFrameWork.Utility;
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Threading.Tasks;
+
 using UnityEditor;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace SymphonyFrameWork.Editor
 {
     /// <summary> SceneLoaderが追跡するシーン状態を一覧表示する管理パネル。 </summary>
     [UxmlElement]
-    public sealed partial class SceneLoaderWindow : SymphonyVisualElement
+    public sealed partial class SceneLoaderWindow : SymphonyVisualElement, IDisposable
     {
-        private Dictionary<string, SceneLoadEntity> _sceneDict;
-        private FieldInfo _registryField;
-        private ListView _sceneList;
-
         /// <summary> 管理パネル用UXMLの非同期初期化を開始する。 </summary>
         public SceneLoaderWindow() : base(
             SymphonyAdministrator.UITK_UXML_PATH + "SceneLoaderWindow.uxml",
@@ -26,78 +21,126 @@ namespace SymphonyFrameWork.Editor
             LoadType.AssetDataBase)
         { }
 
-        /// <summary> SceneLoaderの追跡データを参照するシーン一覧を構成する。 </summary>
-        protected override ValueTask Initialize_S(VisualElement container)
+        private IDisposable _sceneSubscription;
+        private List<SceneLoadDto> _sceneItems = new();
+        private ListView _sceneList;
+        private bool _isDisposed;
+
+        /// <summary> ViewModelとEditor callbackの購読を解除する。 </summary>
+        public void Dispose()
         {
-            _registryField = typeof(SceneLoader).GetField(
-                "_registry",
-                BindingFlags.Static | BindingFlags.NonPublic);
-
-            UpdateSceneDict();
-
-            _sceneList = container.Q<ListView>("scene-list");
-
-            _sceneList.makeItem = () => new Label();
-
-            _sceneList.bindItem = (element, index) =>
+            if (_isDisposed)
             {
-                var kvp = GetSceneList()[index];
-                (element as Label).text = $"Name : {kvp.Key}\nState : {kvp.Value.State}, Priority : {kvp.Value.Priority}";
-            };
-
-            _sceneList.itemsSource = GetSceneList();
-            _sceneList.selectionType = SelectionType.None;
-
-            return default;
-        }
-
-        /// <summary> SceneLoader内部の最新シーン辞書参照を取得する。 </summary>
-        private void UpdateSceneDict()
-        {
-            if (_registryField == null) return;
-
-            var sceneLoadRegistryInstance = _registryField.GetValue(null);
-
-            if (sceneLoadRegistryInstance == null)
-            {
-                _sceneDict = new Dictionary<string, SceneLoadEntity>();
                 return;
             }
 
-            var sceneDictField =
-                sceneLoadRegistryInstance.GetType()
-                .GetField("_entities",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-
-            if (sceneDictField != null)
-            {
-                _sceneDict =
-                    (Dictionary<string, SceneLoadEntity>)sceneDictField.GetValue(
-                        sceneLoadRegistryInstance);
-            }
-            else
-            {
-                _sceneDict = new Dictionary<string, SceneLoadEntity>();
-            }
+            _isDisposed = true;
+            EditorApplication.playModeStateChanged -= PlayModeStateChangedHandler;
+            EditorApplication.delayCall -= DelayedBindViewModel;
+            UnbindViewModel();
         }
 
-        /// <summary> 表示時の列挙変更を避けるため、シーン辞書のスナップショットを生成する。 </summary>
-        private List<KeyValuePair<string, SceneLoadEntity>> GetSceneList()
+        /// <summary> Scene Load ViewModelを購読するシーン一覧を構成する。 </summary>
+        /// <param name="container"> UXMLから生成されたルート要素。 </param>
+        /// <returns> 同期的に完了する初期化処理。 </returns>
+        protected override ValueTask Initialize_S(VisualElement container)
         {
-            UpdateSceneDict();
-            return _sceneDict != null
-                ? new List<KeyValuePair<string, SceneLoadEntity>>(_sceneDict)
-                : new List<KeyValuePair<string, SceneLoadEntity>>();
+            if (_isDisposed)
+            {
+                return default;
+            }
+
+            _sceneList = container.Q<ListView>("scene-list");
+            _sceneList.makeItem = () => new Label();
+            _sceneList.bindItem = (element, index) =>
+            {
+                SceneLoadDto scene = _sceneItems[index];
+                (element as Label).text =
+                    $"Name : {scene.SceneName}\n"
+                    + $"State : {scene.State}, Priority : {scene.Priority}\n"
+                    + $"Progress : {scene.Progress:P0}, Active : {scene.IsActive}";
+            };
+            _sceneList.itemsSource = _sceneItems;
+            _sceneList.selectionType = SelectionType.None;
+
+            EditorApplication.playModeStateChanged += PlayModeStateChangedHandler;
+            BindViewModel();
+            return default;
         }
 
-        /// <summary> シーン一覧を最新の追跡状態で再構築する。 </summary>
-        public void Update()
+        /// <summary> Play Mode遷移に合わせて現在のViewModelへ接続し直す。 </summary>
+        /// <param name="state"> 遷移後のPlay Mode状態。 </param>
+        private void PlayModeStateChangedHandler(PlayModeStateChange state)
         {
-            if (_sceneList != null)
+            switch (state)
             {
-                _sceneList.itemsSource = GetSceneList();
-                _sceneList.Rebuild();
+                case PlayModeStateChange.EnteredPlayMode:
+                    EditorApplication.delayCall -= DelayedBindViewModel;
+                    EditorApplication.delayCall += DelayedBindViewModel;
+                    break;
+
+                case PlayModeStateChange.ExitingPlayMode:
+                case PlayModeStateChange.EnteredEditMode:
+                    EditorApplication.delayCall -= DelayedBindViewModel;
+                    UnbindViewModel();
+                    ApplyScenes(Array.Empty<SceneLoadDto>());
+                    break;
             }
         }
+
+        /// <summary> Scene Loader初期化後のEditor callbackでViewModelへ接続する。 </summary>
+        private void DelayedBindViewModel()
+        {
+            EditorApplication.delayCall -= DelayedBindViewModel;
+            BindViewModel();
+        }
+
+        /// <summary> 現在のScene Load ViewModelへ接続する。 </summary>
+        private void BindViewModel()
+        {
+            UnbindViewModel();
+
+            if (_isDisposed
+                || !EditorApplication.isPlaying
+                || !SceneLoader.IsInitialized)
+            {
+                ApplyScenes(Array.Empty<SceneLoadDto>());
+                return;
+            }
+
+            SceneLoadViewModel viewModel = SceneLoader.CurrentViewModel;
+            if (viewModel == null)
+            {
+                ApplyScenes(Array.Empty<SceneLoadDto>());
+                return;
+            }
+
+            _sceneSubscription = viewModel.Scenes.Subscribe(ApplyScenes);
+        }
+
+        /// <summary> 現在のViewModel購読を解除する。 </summary>
+        private void UnbindViewModel()
+        {
+            _sceneSubscription?.Dispose();
+            _sceneSubscription = null;
+        }
+
+        /// <summary> 最新Dto一覧をListViewへ反映する。 </summary>
+        /// <param name="sceneDtos"> ViewModelが公開した変更不能なDto一覧。 </param>
+        private void ApplyScenes(IReadOnlyList<SceneLoadDto> sceneDtos)
+        {
+            _sceneItems = sceneDtos == null
+                ? new List<SceneLoadDto>()
+                : new List<SceneLoadDto>(sceneDtos);
+
+            if (_sceneList == null)
+            {
+                return;
+            }
+
+            _sceneList.itemsSource = _sceneItems;
+            _sceneList.Rebuild();
+        }
+
     }
 }

--- a/Editor/Debug/SymphonyMcpTools.cs
+++ b/Editor/Debug/SymphonyMcpTools.cs
@@ -15,8 +15,7 @@ using Newtonsoft.Json;
 namespace SymphonyFrameWork.Editor.Debugger
 {
     /// <summary>
-    ///     MCPや自動化スクリプトからSymphonyのランタイム状態をJSONで読み取るための暫定ツール群。
-    ///     Architecture Revision Phase 3でAdaptor QueryとInfoへ置き換える。
+    ///     MCPや自動化スクリプトからSymphonyのランタイム状態をJSONで読み取るためのツール群。
     /// </summary>
     public static class SymphonyMcpTools
     {
@@ -85,20 +84,26 @@ namespace SymphonyFrameWork.Editor.Debugger
                     });
                 }
 
-                var scenes = SceneLoader.TrackedScenes
-                    .Select(pair => new
+                IReadOnlyList<SceneLoadInfo> sceneInfos = SceneLoader.GetSceneInfos();
+                var scenes = sceneInfos
+                    .Select(sceneInfo => new
                     {
-                        name = pair.Key,
-                        state = pair.Value.State.ToString(),
-                        priority = pair.Value.Priority
+                        name = sceneInfo.SceneName,
+                        state = sceneInfo.State.ToString(),
+                        priority = sceneInfo.Priority,
+                        progress = sceneInfo.Progress,
+                        isActive = sceneInfo.IsActive
                     })
                     .ToArray();
+                string activeSceneName = sceneInfos
+                    .FirstOrDefault(sceneInfo => sceneInfo.IsActive)
+                    .SceneName;
 
                 return Serialize(new
                 {
                     initialized = true,
                     scenes,
-                    activeSceneName = SceneLoader.ActiveSceneName
+                    activeSceneName
                 });
             }
             catch (Exception exception)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **2.12.0**
+- 現在のバージョン: **2.13.0**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること
@@ -162,6 +162,23 @@ public async void OpenGameScene()
 ```
 
 `SceneLoadRequest`はシーン名とActive Scene選択用の優先度を1つの値として扱います。複数シーンでは`SceneLoadRequest[]`を`LoadScenes`へ渡せるため、シーン名と優先度の対応を崩しません。進捗の推奨契約は`IProgress<float>`です。既存のシーン名と`Action<float>`を使うoverloadも互換性のため利用できます。
+
+追跡中の全シーンは、変更不能な`SceneLoadInfo`のスナップショットとして取得できます。取得後にロード状態が変わっても、既に取得した値は変化しません。
+
+```csharp
+foreach (SceneLoadInfo sceneInfo in SceneLoader.GetSceneInfos())
+{
+    Debug.Log(
+        $"{sceneInfo.SceneName}: {sceneInfo.State}, "
+        + $"Priority={sceneInfo.Priority}, Progress={sceneInfo.Progress:P0}, "
+        + $"Active={sceneInfo.IsActive}");
+}
+
+if (SceneLoader.TryGetSceneInfo("Game", out SceneLoadInfo gameScene))
+{
+    Debug.Log($"Game scene progress: {gameScene.Progress:P0}");
+}
+```
 
 Scene Loaderは非同期ロード、進捗、複数シーン、優先度によるActive Scene切り替えをまとめて扱います。ルートGameObjectが`IInjectable<T...>`や`IInitializeAsync`を実装している場合は、注入と初期化の完了も待機します。
 

--- a/Runtime/System/SceneLoader/Internal/Adaptor.meta
+++ b/Runtime/System/SceneLoader/Internal/Adaptor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3f977715673c33429dfe57d02bdaa81
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadDto.cs
+++ b/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadDto.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+namespace SymphonyFrameWork.System.SceneLoad
+{
+    /// <summary> Scene Loadの表示に必要な不変の更新値。 </summary>
+    internal readonly struct SceneLoadDto : IEquatable<SceneLoadDto>
+    {
+        /// <summary> 表示に必要な値を指定して更新値を生成する。 </summary>
+        /// <param name="sceneName"> シーン名。 </param>
+        /// <param name="state"> ロード状態。 </param>
+        /// <param name="priority"> Active Scene選択に使用する優先度。 </param>
+        /// <param name="progress"> 0から1の範囲に正規化された処理進捗。 </param>
+        /// <param name="isActive"> Active Sceneの場合はtrue。 </param>
+        internal SceneLoadDto(
+            string sceneName,
+            SceneLoadState state,
+            int priority,
+            float progress,
+            bool isActive)
+        {
+            SceneName = sceneName;
+            State = state;
+            Priority = priority;
+            Progress = progress;
+            IsActive = isActive;
+        }
+
+        /// <summary> シーン名。 </summary>
+        internal string SceneName { get; }
+
+        /// <summary> 現在のロード状態。 </summary>
+        internal SceneLoadState State { get; }
+
+        /// <summary> Active Scene選択に使用する優先度。 </summary>
+        internal int Priority { get; }
+
+        /// <summary> 0から1の範囲に正規化された処理進捗。 </summary>
+        internal float Progress { get; }
+
+        /// <summary> Active Sceneの場合はtrue。 </summary>
+        internal bool IsActive { get; }
+
+        /// <summary> 指定した更新値と同値か判定する。 </summary>
+        /// <param name="other"> 比較対象。 </param>
+        /// <returns> すべての値が一致する場合はtrue。 </returns>
+        public bool Equals(SceneLoadDto other) =>
+            string.Equals(SceneName, other.SceneName, StringComparison.Ordinal)
+            && State == other.State
+            && Priority == other.Priority
+            && Progress.Equals(other.Progress)
+            && IsActive == other.IsActive;
+
+        /// <summary> 指定したオブジェクトと同値か判定する。 </summary>
+        /// <param name="obj"> 比較対象。 </param>
+        /// <returns> 同値のSceneLoadDtoの場合はtrue。 </returns>
+        public override bool Equals(object obj) =>
+            obj is SceneLoadDto other && Equals(other);
+
+        /// <summary> 更新値の全値に基づくハッシュコードを返す。 </summary>
+        /// <returns> ハッシュコード。 </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = SceneName != null
+                    ? StringComparer.Ordinal.GetHashCode(SceneName)
+                    : 0;
+                hashCode = (hashCode * 397) ^ (int)State;
+                hashCode = (hashCode * 397) ^ Priority;
+                hashCode = (hashCode * 397) ^ Progress.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsActive.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadDto.cs.meta
+++ b/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadDto.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9dadd5cade4187d448135f54357d5883

--- a/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadQuery.cs
+++ b/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadQuery.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SymphonyFrameWork.System.SceneLoad
+{
+    /// <summary> Scene RegistryとEntityを公開InfoまたはView用Dtoへ変換する。 </summary>
+    internal sealed class SceneLoadQuery
+    {
+        /// <summary> 読み取り対象のRegistryを指定してQueryを生成する。 </summary>
+        /// <param name="registry"> Scene Entityを所有するRegistry。 </param>
+        internal SceneLoadQuery(SceneLoadRegistry registry)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        private readonly SceneLoadRegistry _registry;
+
+        /// <summary> 指定したSceneの公開スナップショットを取得する。 </summary>
+        /// <param name="sceneName"> 取得するシーン名。 </param>
+        /// <param name="sceneInfo"> 取得できた公開スナップショット。 </param>
+        /// <returns> 追跡中のSceneを取得できた場合はtrue。 </returns>
+        internal bool TryGetInfo(string sceneName, out SceneLoadInfo sceneInfo)
+        {
+            if (!_registry.TryGet(sceneName, out SceneLoadEntity entity))
+            {
+                sceneInfo = default;
+                return false;
+            }
+
+            string activeSceneName = _registry.ActiveSceneName;
+            sceneInfo = CreateInfo(entity, activeSceneName);
+            return true;
+        }
+
+        /// <summary> 追跡中Sceneの公開スナップショット一覧を返す。 </summary>
+        /// <returns> Scene名のordinal昇順で並んだ変更不能な一覧。 </returns>
+        internal IReadOnlyList<SceneLoadInfo> GetInfos()
+        {
+            List<SceneLoadEntity> entities = GetSortedEntities();
+            string activeSceneName = _registry.ActiveSceneName;
+            var sceneInfos = new SceneLoadInfo[entities.Count];
+
+            for (int i = 0; i < entities.Count; i++)
+            {
+                sceneInfos[i] = CreateInfo(entities[i], activeSceneName);
+            }
+
+            return Array.AsReadOnly(sceneInfos);
+        }
+
+        /// <summary> 追跡中SceneのView用更新値一覧を返す。 </summary>
+        /// <returns> Scene名のordinal昇順で並んだ変更不能な一覧。 </returns>
+        internal IReadOnlyList<SceneLoadDto> GetDtos()
+        {
+            List<SceneLoadEntity> entities = GetSortedEntities();
+            string activeSceneName = _registry.ActiveSceneName;
+            var sceneDtos = new SceneLoadDto[entities.Count];
+
+            for (int i = 0; i < entities.Count; i++)
+            {
+                SceneLoadEntity entity = entities[i];
+                sceneDtos[i] = new SceneLoadDto(
+                    entity.Name,
+                    entity.State,
+                    entity.Priority,
+                    entity.Progress,
+                    IsActive(entity.Name, activeSceneName));
+            }
+
+            return Array.AsReadOnly(sceneDtos);
+        }
+
+        /// <summary> Entityから公開スナップショットを生成する。 </summary>
+        /// <param name="entity"> 変換元Entity。 </param>
+        /// <param name="activeSceneName"> 取得時点のActive Scene名。 </param>
+        /// <returns> 公開スナップショット。 </returns>
+        private static SceneLoadInfo CreateInfo(
+            SceneLoadEntity entity,
+            string activeSceneName) =>
+            new(
+                entity.Name,
+                entity.State,
+                entity.Priority,
+                entity.Progress,
+                IsActive(entity.Name, activeSceneName));
+
+        /// <summary> 2つのScene名が同じActive Sceneを示すか判定する。 </summary>
+        /// <param name="sceneName"> 判定するScene名。 </param>
+        /// <param name="activeSceneName"> 取得時点のActive Scene名。 </param>
+        /// <returns> 一致する場合はtrue。 </returns>
+        private static bool IsActive(string sceneName, string activeSceneName) =>
+            string.Equals(sceneName, activeSceneName, StringComparison.Ordinal);
+
+        /// <summary> RegistryのEntityをScene名のordinal昇順で複製する。 </summary>
+        /// <returns> 並べ替え済みEntity一覧。 </returns>
+        private List<SceneLoadEntity> GetSortedEntities()
+        {
+            var entities = new List<SceneLoadEntity>(_registry.Entities.Values);
+            entities.Sort(CompareEntities);
+            return entities;
+        }
+
+        /// <summary> 2つのEntityをScene名のordinal順で比較する。 </summary>
+        /// <param name="left"> 左辺のEntity。 </param>
+        /// <param name="right"> 右辺のEntity。 </param>
+        /// <returns> 比較結果。 </returns>
+        private static int CompareEntities(
+            SceneLoadEntity left,
+            SceneLoadEntity right) =>
+            StringComparer.Ordinal.Compare(left.Name, right.Name);
+    }
+}

--- a/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadQuery.cs.meta
+++ b/Runtime/System/SceneLoader/Internal/Adaptor/SceneLoadQuery.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd873546755b1194bb7ba6ab5af73bb1

--- a/Runtime/System/SceneLoader/Internal/View.meta
+++ b/Runtime/System/SceneLoader/Internal/View.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37e3a792d2ceff94dac29893e9bac8a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/System/SceneLoader/Internal/View/SceneLoadViewModel.cs
+++ b/Runtime/System/SceneLoader/Internal/View/SceneLoadViewModel.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+
+using SymphonyFrameWork.Core;
+
+namespace SymphonyFrameWork.System.SceneLoad
+{
+    /// <summary> Scene Loadの状態変更を表示用ReactivePropertyへ変換する。 </summary>
+    internal sealed class SceneLoadViewModel : IDisposable
+    {
+        /// <summary> Queryと状態変更元Serviceを指定してViewModelを生成する。 </summary>
+        /// <param name="query"> 表示用Dtoを生成するQuery。 </param>
+        /// <param name="service"> 状態変更eventを発行するService。 </param>
+        internal SceneLoadViewModel(
+            SceneLoadQuery query,
+            SceneLoadService service)
+        {
+            _query = query ?? throw new ArgumentNullException(nameof(query));
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _scenes = new ReactiveProperty<IReadOnlyList<SceneLoadDto>>(
+                _query.GetDtos(),
+                new SceneLoadDtoListComparer());
+            _service.OnStateChanged += StateChangedHandler;
+        }
+
+        /// <summary> 追跡中Sceneの表示用更新値一覧。 </summary>
+        internal IReadOnlyReactiveProperty<IReadOnlyList<SceneLoadDto>> Scenes => _scenes;
+
+        private readonly SceneLoadQuery _query;
+        private readonly SceneLoadService _service;
+        private readonly ReactiveProperty<IReadOnlyList<SceneLoadDto>> _scenes;
+
+        private bool _isDisposed;
+
+        /// <summary> Service eventの購読とReactivePropertyを破棄する。 </summary>
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _service.OnStateChanged -= StateChangedHandler;
+            _scenes.Dispose();
+        }
+
+        /// <summary> Serviceの状態変更を最新Dto一覧へ反映する。 </summary>
+        private void StateChangedHandler()
+        {
+            _scenes.SetValue(_query.GetDtos());
+        }
+
+        /// <summary> Scene Load Dto一覧を内容で比較する。 </summary>
+        private sealed class SceneLoadDtoListComparer : IEqualityComparer<IReadOnlyList<SceneLoadDto>>
+        {
+            /// <summary> 2つのDto一覧が同じ順序と値を持つか判定する。 </summary>
+            /// <param name="left"> 左辺の一覧。 </param>
+            /// <param name="right"> 右辺の一覧。 </param>
+            /// <returns> 内容が同じ場合はtrue。 </returns>
+            public bool Equals(
+                IReadOnlyList<SceneLoadDto> left,
+                IReadOnlyList<SceneLoadDto> right)
+            {
+                if (ReferenceEquals(left, right))
+                {
+                    return true;
+                }
+
+                if (left == null || right == null || left.Count != right.Count)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < left.Count; i++)
+                {
+                    if (!left[i].Equals(right[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            /// <summary> Dto一覧の内容に基づくハッシュコードを返す。 </summary>
+            /// <param name="sceneDtos"> ハッシュ化する一覧。 </param>
+            /// <returns> ハッシュコード。 </returns>
+            public int GetHashCode(IReadOnlyList<SceneLoadDto> sceneDtos)
+            {
+                if (sceneDtos == null)
+                {
+                    return 0;
+                }
+
+                unchecked
+                {
+                    int hashCode = 17;
+                    for (int i = 0; i < sceneDtos.Count; i++)
+                    {
+                        hashCode = (hashCode * 31) ^ sceneDtos[i].GetHashCode();
+                    }
+
+                    return hashCode;
+                }
+            }
+        }
+    }
+}

--- a/Runtime/System/SceneLoader/Internal/View/SceneLoadViewModel.cs.meta
+++ b/Runtime/System/SceneLoader/Internal/View/SceneLoadViewModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5f7b1e26f69c234bb176e7a15a2da55

--- a/Runtime/System/SceneLoader/SceneLoadInfo.cs
+++ b/Runtime/System/SceneLoader/SceneLoadInfo.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+namespace SymphonyFrameWork.System.SceneLoad
+{
+    /// <summary> 追跡中シーンの状態を表す不変なスナップショット。 </summary>
+    public readonly struct SceneLoadInfo : IEquatable<SceneLoadInfo>
+    {
+        /// <summary> Queryが抽出した追跡状態からスナップショットを生成する。 </summary>
+        /// <param name="sceneName"> シーン名。 </param>
+        /// <param name="state"> ロード状態。 </param>
+        /// <param name="priority"> Active Scene選択に使用する優先度。 </param>
+        /// <param name="progress"> 0から1の範囲に正規化された処理進捗。 </param>
+        /// <param name="isActive"> Active Sceneの場合はtrue。 </param>
+        internal SceneLoadInfo(
+            string sceneName,
+            SceneLoadState state,
+            int priority,
+            float progress,
+            bool isActive)
+        {
+            SceneName = sceneName;
+            State = state;
+            Priority = priority;
+            Progress = progress;
+            IsActive = isActive;
+        }
+
+        /// <summary> シーン名。 </summary>
+        public string SceneName { get; }
+
+        /// <summary> 現在のロード状態。 </summary>
+        public SceneLoadState State { get; }
+
+        /// <summary> Active Scene選択に使用する優先度。 </summary>
+        public int Priority { get; }
+
+        /// <summary> 0から1の範囲に正規化された処理進捗。 </summary>
+        public float Progress { get; }
+
+        /// <summary> Active Sceneの場合はtrue。 </summary>
+        public bool IsActive { get; }
+
+        /// <summary> 2つのスナップショットが同じ値を持つか判定する。 </summary>
+        /// <param name="left"> 左辺のスナップショット。 </param>
+        /// <param name="right"> 右辺のスナップショット。 </param>
+        /// <returns> 同値の場合はtrue。 </returns>
+        public static bool operator ==(SceneLoadInfo left, SceneLoadInfo right) =>
+            left.Equals(right);
+
+        /// <summary> 2つのスナップショットが異なる値を持つか判定する。 </summary>
+        /// <param name="left"> 左辺のスナップショット。 </param>
+        /// <param name="right"> 右辺のスナップショット。 </param>
+        /// <returns> 異なる場合はtrue。 </returns>
+        public static bool operator !=(SceneLoadInfo left, SceneLoadInfo right) =>
+            !left.Equals(right);
+
+        /// <summary> 指定したスナップショットと同値か判定する。 </summary>
+        /// <param name="other"> 比較対象。 </param>
+        /// <returns> すべての値が一致する場合はtrue。 </returns>
+        public bool Equals(SceneLoadInfo other) =>
+            string.Equals(SceneName, other.SceneName, StringComparison.Ordinal)
+            && State == other.State
+            && Priority == other.Priority
+            && Progress.Equals(other.Progress)
+            && IsActive == other.IsActive;
+
+        /// <summary> 指定したオブジェクトと同値か判定する。 </summary>
+        /// <param name="obj"> 比較対象。 </param>
+        /// <returns> 同値のSceneLoadInfoの場合はtrue。 </returns>
+        public override bool Equals(object obj) =>
+            obj is SceneLoadInfo other && Equals(other);
+
+        /// <summary> スナップショットの全値に基づくハッシュコードを返す。 </summary>
+        /// <returns> ハッシュコード。 </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = SceneName != null
+                    ? StringComparer.Ordinal.GetHashCode(SceneName)
+                    : 0;
+                hashCode = (hashCode * 397) ^ (int)State;
+                hashCode = (hashCode * 397) ^ Priority;
+                hashCode = (hashCode * 397) ^ Progress.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsActive.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Runtime/System/SceneLoader/SceneLoadInfo.cs.meta
+++ b/Runtime/System/SceneLoader/SceneLoadInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6391a185da6d39a4ca11eda8f7d94f50

--- a/Runtime/System/SceneLoader/SceneLoader.cs
+++ b/Runtime/System/SceneLoader/SceneLoader.cs
@@ -15,6 +15,8 @@ namespace SymphonyFrameWork.System.SceneLoad
     {
         private static SceneLoadRegistry _registry;
         private static SceneLoadService _service;
+        private static SceneLoadQuery _query;
+        private static SceneLoadViewModel _viewModel;
 
         /// <summary> ロードされているシーンを返す。 </summary>
         /// <param name="sceneName"> 取得するシーン名。 </param>
@@ -32,7 +34,7 @@ namespace SymphonyFrameWork.System.SceneLoad
         public static bool IsExist(string sceneName)
         {
             EnsureInitialized();
-            return _registry.Contains(sceneName);
+            return _query.TryGetInfo(sceneName, out _);
         }
 
         /// <summary> シーンの状態を返す。 </summary>
@@ -43,14 +45,34 @@ namespace SymphonyFrameWork.System.SceneLoad
         {
             EnsureInitialized();
 
-            if (_registry.TryGet(sceneName, out SceneLoadEntity entity))
+            if (_query.TryGetInfo(sceneName, out SceneLoadInfo sceneInfo))
             {
-                state = entity.State;
+                state = sceneInfo.State;
                 return true;
             }
 
             state = SceneLoadState.None;
             return false;
+        }
+
+        /// <summary> 追跡中シーンの不変な状態スナップショット一覧を返す。 </summary>
+        /// <returns> シーン名のordinal昇順で並んだ変更不能な一覧。 </returns>
+        public static IReadOnlyList<SceneLoadInfo> GetSceneInfos()
+        {
+            EnsureInitialized();
+            return _query.GetInfos();
+        }
+
+        /// <summary> 指定した追跡中シーンの不変な状態スナップショットを返す。 </summary>
+        /// <param name="sceneName"> 状態を取得するシーン名。 </param>
+        /// <param name="sceneInfo"> 取得できた状態スナップショット。 </param>
+        /// <returns> 状態を取得できた場合はtrue。 </returns>
+        public static bool TryGetSceneInfo(
+            string sceneName,
+            out SceneLoadInfo sceneInfo)
+        {
+            EnsureInitialized();
+            return _query.TryGetInfo(sceneName, out sceneInfo);
         }
 
         /// <summary> シーンをActive Sceneにする。 </summary>
@@ -259,14 +281,14 @@ namespace SymphonyFrameWork.System.SceneLoad
         }
 
         /// <summary> Scene Loaderが初期化済みかどうか。 </summary>
-        internal static bool IsInitialized => _service != null && _registry != null;
+        internal static bool IsInitialized =>
+            _service != null
+            && _registry != null
+            && _query != null
+            && _viewModel != null;
 
-        /// <summary> 名前をキーとする追跡中Scene Entity一覧。 </summary>
-        internal static IReadOnlyDictionary<string, SceneLoadEntity> TrackedScenes =>
-            _registry?.Entities;
-
-        /// <summary> Scene Loaderが記録しているActive Scene名。 </summary>
-        internal static string ActiveSceneName => _registry?.ActiveSceneName;
+        /// <summary> Compositionが所有する現在のScene Load ViewModel。 </summary>
+        internal static SceneLoadViewModel CurrentViewModel => _viewModel;
 
         /// <summary> OrchestratorからScene Loaderを初期化する。 </summary>
         internal static void Initialize()
@@ -274,12 +296,17 @@ namespace SymphonyFrameWork.System.SceneLoad
             ResetRuntimeState();
             _registry = new SceneLoadRegistry();
             _service = new SceneLoadService(_registry, new UnitySceneLoader());
+            _query = new SceneLoadQuery(_registry);
+            _viewModel = new SceneLoadViewModel(_query, _service);
         }
 
         /// <summary> 追跡状態とServiceを破棄して未初期化状態へ戻す。 </summary>
         internal static void ResetRuntimeState()
         {
+            _viewModel?.Dispose();
             _registry?.Clear();
+            _viewModel = null;
+            _query = null;
             _service = null;
             _registry = null;
         }
@@ -300,7 +327,7 @@ namespace SymphonyFrameWork.System.SceneLoad
         /// <summary> Scene Loaderが利用可能な状態か検証する。 </summary>
         private static void EnsureInitialized()
         {
-            if (_service == null || _registry == null)
+            if (!IsInitialized)
             {
                 throw new SymphonyNotInitializedException(typeof(SceneLoader));
             }

--- a/Samples/Runtime/SceneLoaderSample/Scripts/SceneLoaderSample_Controller.cs
+++ b/Samples/Runtime/SceneLoaderSample/Scripts/SceneLoaderSample_Controller.cs
@@ -1,4 +1,4 @@
-using SymphonyFrameWork.System.SceneLoad;
+﻿using SymphonyFrameWork.System.SceneLoad;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -208,12 +208,20 @@ namespace SymphonyFrameWork.Samples.SceneLoaderSample
             GUILayout.EndArea();
         }
 
-        /// <summary> 指定シーンの存在有無とロード状態をラベル表示する。 </summary>
+        /// <summary> 指定シーンの公開状態スナップショットをラベル表示する。 </summary>
+        /// <param name="sceneName"> 表示するScene名。 </param>
         private void DrawSceneStatus(string sceneName)
         {
-            bool exists = SceneLoader.IsExist(sceneName);
-            string state = SceneLoader.TryGetState(sceneName, out SceneLoadState loadState) ? loadState.ToString() : "Untracked";
-            GUILayout.Label($"{sceneName} | Exists: {exists} | State: {state}");
+            if (!SceneLoader.TryGetSceneInfo(sceneName, out SceneLoadInfo sceneInfo))
+            {
+                GUILayout.Label($"{sceneName} | Untracked");
+                return;
+            }
+
+            GUILayout.Label(
+                $"{sceneInfo.SceneName} | State: {sceneInfo.State} | "
+                + $"Priority: {sceneInfo.Priority} | Progress: {sceneInfo.Progress:P0} | "
+                + $"Active: {sceneInfo.IsActive}");
         }
 
         /// <summary> 表示上限を維持しながら実況ログを末尾へ追加する。 </summary>

--- a/Tests/Editor/SceneLoadInfoTests.cs
+++ b/Tests/Editor/SceneLoadInfoTests.cs
@@ -1,0 +1,79 @@
+﻿using NUnit.Framework;
+
+using SymphonyFrameWork.System.SceneLoad;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> SceneLoadInfoの保持値と値等値性を検証する。 </summary>
+    public sealed class SceneLoadInfoTests
+    {
+        /// <summary> Queryから渡されたScene状態を変更せず保持する。 </summary>
+        [Test]
+        public void Constructor_ValidValues_StoresSnapshot()
+        {
+            var sceneInfo = new SceneLoadInfo(
+                "Game",
+                SceneLoadState.Loading,
+                5,
+                0.25f,
+                true);
+
+            Assert.That(sceneInfo.SceneName, Is.EqualTo("Game"));
+            Assert.That(sceneInfo.State, Is.EqualTo(SceneLoadState.Loading));
+            Assert.That(sceneInfo.Priority, Is.EqualTo(5));
+            Assert.That(sceneInfo.Progress, Is.EqualTo(0.25f));
+            Assert.That(sceneInfo.IsActive, Is.True);
+        }
+
+        /// <summary> 全値が同じスナップショットは等値になる。 </summary>
+        [Test]
+        public void Equality_SameValues_ReturnsTrue()
+        {
+            var left = new SceneLoadInfo(
+                "Game",
+                SceneLoadState.Complete,
+                2,
+                1f,
+                false);
+            var right = new SceneLoadInfo(
+                "Game",
+                SceneLoadState.Complete,
+                2,
+                1f,
+                false);
+
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(left == right, Is.True);
+            Assert.That(left != right, Is.False);
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary> いずれかの値が異なるスナップショットは非等値になる。 </summary>
+        [Test]
+        public void Equality_DifferentProgress_ReturnsFalse()
+        {
+            var left = new SceneLoadInfo(
+                "Game",
+                SceneLoadState.Loading,
+                2,
+                0.25f,
+                false);
+            var right = new SceneLoadInfo(
+                "Game",
+                SceneLoadState.Loading,
+                2,
+                0.5f,
+                false);
+
+            Assert.That(left, Is.Not.EqualTo(right));
+            Assert.That(left != right, Is.True);
+        }
+
+        /// <summary> 既定値同士も安全に比較できる。 </summary>
+        [Test]
+        public void Equality_DefaultValues_ReturnsTrue()
+        {
+            Assert.That(default(SceneLoadInfo), Is.EqualTo(default(SceneLoadInfo)));
+        }
+    }
+}

--- a/Tests/Editor/SceneLoadInfoTests.cs.meta
+++ b/Tests/Editor/SceneLoadInfoTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 187057454a1ab594aab4fea10ba51760

--- a/Tests/Editor/SceneLoadQueryTests.cs
+++ b/Tests/Editor/SceneLoadQueryTests.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.SceneLoad;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> SceneLoadQueryのInfo／Dto変換とスナップショット性を検証する。 </summary>
+    public sealed class SceneLoadQueryTests
+    {
+        /// <summary> null、空、未登録のScene名は未検出として返す。 </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("Missing")]
+        public void TryGetInfo_UntrackedScene_ReturnsFalse(string sceneName)
+        {
+            var query = new SceneLoadQuery(new SceneLoadRegistry());
+
+            bool found = query.TryGetInfo(sceneName, out SceneLoadInfo sceneInfo);
+
+            Assert.That(found, Is.False);
+            Assert.That(sceneInfo, Is.EqualTo(default(SceneLoadInfo)));
+        }
+
+        /// <summary> Entityの全観測値とActive判定をInfoへ変換する。 </summary>
+        [Test]
+        public void TryGetInfo_TrackedActiveScene_ReturnsSnapshot()
+        {
+            var registry = new SceneLoadRegistry();
+            registry.RegisterLoaded(new SceneLoadRequest("Game", 7));
+            registry.SetActiveScene("Game");
+            var query = new SceneLoadQuery(registry);
+
+            bool found = query.TryGetInfo("Game", out SceneLoadInfo sceneInfo);
+
+            Assert.That(found, Is.True);
+            Assert.That(sceneInfo.SceneName, Is.EqualTo("Game"));
+            Assert.That(sceneInfo.State, Is.EqualTo(SceneLoadState.Complete));
+            Assert.That(sceneInfo.Priority, Is.EqualTo(7));
+            Assert.That(sceneInfo.Progress, Is.EqualTo(1f));
+            Assert.That(sceneInfo.IsActive, Is.True);
+        }
+
+        /// <summary> 一覧をScene名のordinal昇順で返す。 </summary>
+        [Test]
+        public void GetInfos_MultipleScenes_ReturnsOrdinalOrder()
+        {
+            var registry = new SceneLoadRegistry();
+            registry.RegisterLoaded(new SceneLoadRequest("Zebra"));
+            registry.RegisterLoaded(new SceneLoadRequest("Alpha"));
+            registry.RegisterLoaded(new SceneLoadRequest("middle"));
+            var query = new SceneLoadQuery(registry);
+
+            IReadOnlyList<SceneLoadInfo> sceneInfos = query.GetInfos();
+
+            Assert.That(
+                new[]
+                {
+                    sceneInfos[0].SceneName,
+                    sceneInfos[1].SceneName,
+                    sceneInfos[2].SceneName
+                },
+                Is.EqualTo(new[] { "Alpha", "Zebra", "middle" }));
+        }
+
+        /// <summary> 取得済みInfoは後続のEntity更新から独立している。 </summary>
+        [Test]
+        public void GetInfos_EntityChangesAfterRead_PreservesPreviousSnapshot()
+        {
+            var registry = new SceneLoadRegistry();
+            registry.RegisterLoaded(new SceneLoadRequest("Game", 2));
+            var query = new SceneLoadQuery(registry);
+            IReadOnlyList<SceneLoadInfo> previous = query.GetInfos();
+
+            SceneLoadEntity entity = registry.StartLoading(
+                new SceneLoadRequest("Game", 10));
+            entity.ReportProgress(0.5f);
+            IReadOnlyList<SceneLoadInfo> current = query.GetInfos();
+
+            Assert.That(previous[0].State, Is.EqualTo(SceneLoadState.Complete));
+            Assert.That(previous[0].Priority, Is.EqualTo(2));
+            Assert.That(previous[0].Progress, Is.EqualTo(1f));
+            Assert.That(current[0].State, Is.EqualTo(SceneLoadState.Loading));
+            Assert.That(current[0].Priority, Is.EqualTo(10));
+            Assert.That(current[0].Progress, Is.EqualTo(0.5f));
+        }
+
+        /// <summary> ViewModelに必要な値だけをDtoへ変換する。 </summary>
+        [Test]
+        public void GetDtos_TrackedActiveScene_ReturnsDisplayValues()
+        {
+            var registry = new SceneLoadRegistry();
+            registry.RegisterLoaded(new SceneLoadRequest("Game", 3));
+            registry.SetActiveScene("Game");
+            var query = new SceneLoadQuery(registry);
+
+            IReadOnlyList<SceneLoadDto> sceneDtos = query.GetDtos();
+
+            Assert.That(sceneDtos, Has.Count.EqualTo(1));
+            Assert.That(sceneDtos[0].SceneName, Is.EqualTo("Game"));
+            Assert.That(sceneDtos[0].State, Is.EqualTo(SceneLoadState.Complete));
+            Assert.That(sceneDtos[0].Priority, Is.EqualTo(3));
+            Assert.That(sceneDtos[0].Progress, Is.EqualTo(1f));
+            Assert.That(sceneDtos[0].IsActive, Is.True);
+        }
+    }
+}

--- a/Tests/Editor/SceneLoadQueryTests.cs.meta
+++ b/Tests/Editor/SceneLoadQueryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69969d7f3e818284b8060724bc209213

--- a/Tests/Editor/SceneLoadViewModelTests.cs
+++ b/Tests/Editor/SceneLoadViewModelTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.SceneLoad;
+
+using UnityEngine.SceneManagement;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> SceneLoadViewModelの初期値、通知抑制、購読解除を検証する。 </summary>
+    public sealed class SceneLoadViewModelTests
+    {
+        /// <summary> 生成時にQueryの現在値をReactivePropertyへ反映する。 </summary>
+        [Test]
+        public void Constructor_TrackedScene_ExposesInitialDtos()
+        {
+            var registry = new SceneLoadRegistry();
+            registry.RegisterLoaded(new SceneLoadRequest("Game", 4));
+            var service = new SceneLoadService(registry, new FakeSceneLoader());
+            using var viewModel = new SceneLoadViewModel(
+                new SceneLoadQuery(registry),
+                service);
+
+            IReadOnlyList<SceneLoadDto> sceneDtos = viewModel.Scenes.Value;
+
+            Assert.That(sceneDtos, Has.Count.EqualTo(1));
+            Assert.That(sceneDtos[0].SceneName, Is.EqualTo("Game"));
+            Assert.That(sceneDtos[0].Priority, Is.EqualTo(4));
+        }
+
+        /// <summary> Service eventを受けると最新Dto一覧を通知する。 </summary>
+        [Test]
+        public void ServiceStateChanged_NewScene_NotifiesLatestDtos()
+        {
+            var registry = new SceneLoadRegistry();
+            var loader = new FakeSceneLoader();
+            var service = new SceneLoadService(registry, loader);
+            using var viewModel = new SceneLoadViewModel(
+                new SceneLoadQuery(registry),
+                service);
+            IReadOnlyList<SceneLoadDto> notified = null;
+            using IDisposable subscription = viewModel.Scenes.Subscribe(
+                sceneDtos => notified = sceneDtos,
+                notifyCurrent: false);
+            loader.AddLoadedScene("Game");
+
+            service.TryRegisterLoadedScene(new SceneLoadRequest("Game", 6));
+
+            Assert.That(notified, Is.Not.Null);
+            Assert.That(notified, Has.Count.EqualTo(1));
+            Assert.That(notified[0].SceneName, Is.EqualTo("Game"));
+            Assert.That(notified[0].Priority, Is.EqualTo(6));
+        }
+
+        /// <summary> Serviceが同じ状態を通知してもDto内容が同じなら再通知しない。 </summary>
+        [Test]
+        public void ServiceStateChanged_SameDtoContent_DoesNotNotifyAgain()
+        {
+            var registry = new SceneLoadRegistry();
+            var loader = new FakeSceneLoader();
+            var service = new SceneLoadService(registry, loader);
+            using var viewModel = new SceneLoadViewModel(
+                new SceneLoadQuery(registry),
+                service);
+            int notificationCount = 0;
+            using IDisposable subscription = viewModel.Scenes.Subscribe(
+                _ => notificationCount++,
+                notifyCurrent: false);
+            loader.AddLoadedScene("Game");
+            var request = new SceneLoadRequest("Game", 2);
+
+            service.TryRegisterLoadedScene(request);
+            service.TryRegisterLoadedScene(request);
+
+            Assert.That(notificationCount, Is.EqualTo(1));
+        }
+
+        /// <summary> Dispose後はService eventから切り離される。 </summary>
+        [Test]
+        public void Dispose_ServiceStateChanges_DoesNotNotifySubscribers()
+        {
+            var registry = new SceneLoadRegistry();
+            var loader = new FakeSceneLoader();
+            var service = new SceneLoadService(registry, loader);
+            var viewModel = new SceneLoadViewModel(
+                new SceneLoadQuery(registry),
+                service);
+            int notificationCount = 0;
+            viewModel.Scenes.Subscribe(
+                _ => notificationCount++,
+                notifyCurrent: false);
+            viewModel.Dispose();
+            loader.AddLoadedScene("Game");
+
+            service.TryRegisterLoadedScene(new SceneLoadRequest("Game"));
+
+            Assert.That(notificationCount, Is.Zero);
+            Assert.DoesNotThrow(viewModel.Dispose);
+        }
+
+        /// <summary> テスト用にロード済みSceneだけをメモリ上で管理する。 </summary>
+        private sealed class FakeSceneLoader : ISceneLoader
+        {
+            /// <inheritdoc />
+            public string ActiveSceneName { get; private set; }
+
+            private readonly HashSet<string> _loadedSceneNames =
+                new(StringComparer.Ordinal);
+
+            /// <summary> 指定Sceneをロード済み一覧へ追加する。 </summary>
+            /// <param name="sceneName"> 追加するScene名。 </param>
+            internal void AddLoadedScene(string sceneName)
+            {
+                _loadedSceneNames.Add(sceneName);
+            }
+
+            /// <inheritdoc />
+            public IReadOnlyList<string> GetLoadedSceneNames()
+            {
+                return new List<string>(_loadedSceneNames);
+            }
+
+            /// <inheritdoc />
+            public bool TryGetLoadedScene(string sceneName, out Scene scene)
+            {
+                scene = default;
+                return _loadedSceneNames.Contains(sceneName);
+            }
+
+            /// <inheritdoc />
+            public bool TrySetActiveScene(string sceneName)
+            {
+                if (!_loadedSceneNames.Contains(sceneName))
+                {
+                    return false;
+                }
+
+                ActiveSceneName = sceneName;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public ValueTask<bool> LoadSceneAsync(
+                string sceneName,
+                IProgress<float> progress,
+                CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                _loadedSceneNames.Add(sceneName);
+                progress?.Report(1f);
+                return new ValueTask<bool>(true);
+            }
+
+            /// <inheritdoc />
+            public ValueTask<bool> UnloadSceneAsync(
+                string sceneName,
+                IProgress<float> progress,
+                CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                bool removed = _loadedSceneNames.Remove(sceneName);
+                progress?.Report(1f);
+                return new ValueTask<bool>(removed);
+            }
+
+            /// <inheritdoc />
+            public ValueTask InitializeRootObjectsAsync(string sceneName)
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/Tests/Editor/SceneLoadViewModelTests.cs.meta
+++ b/Tests/Editor/SceneLoadViewModelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e3c8891f32724a4d84c6152e7307728

--- a/Tests/Editor/SymphonyMcpToolsTests.cs
+++ b/Tests/Editor/SymphonyMcpToolsTests.cs
@@ -21,7 +21,10 @@ namespace SymphonyFrameWork.Tests
         [Test]
         public void GetSceneLoaderJson_WhenUninitialized_ReturnsValidJson()
         {
-            AssertUninitializedJson(SymphonyMcpTools.GetSceneLoaderJson);
+            JObject result = AssertUninitializedJson(SymphonyMcpTools.GetSceneLoaderJson);
+
+            Assert.That(result["scenes"], Is.Empty);
+            Assert.That(result["activeSceneName"].Type, Is.EqualTo(JTokenType.Null));
         }
 
         /// <summary> Save Data Registryが未初期化でも例外なく有効なJSONを返すことを検証する。 </summary>
@@ -40,7 +43,7 @@ namespace SymphonyFrameWork.Tests
 
         /// <summary> 呼び出しが例外を投げず、未初期化を示すJSONを返すことを検証する。 </summary>
         /// <param name="getJson"> 検証対象のJSON取得処理。 </param>
-        private static void AssertUninitializedJson(Func<string> getJson)
+        private static JObject AssertUninitializedJson(Func<string> getJson)
         {
             string json = null;
             Assert.DoesNotThrow(() => json = getJson());
@@ -48,6 +51,7 @@ namespace SymphonyFrameWork.Tests
             JObject result = null;
             Assert.DoesNotThrow(() => result = JObject.Parse(json));
             Assert.That(result.Value<bool>("initialized"), Is.False);
+            return result;
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
## 概要

Scene Loadの読み取り経路をQueryへ集約し、表示層がRuntime内部構造を直接参照しない構成へ分割します。

## 変更内容

- 公開の不変スナップショット `SceneLoadInfo` と `SceneLoader.GetSceneInfos/TryGetSceneInfo` を追加
- 内部の `SceneLoadQuery` / `SceneLoadDto` / `SceneLoadViewModel` を追加
- Symphony AdministratorのScene Loader表示をViewModel購読へ変更し、非公開フィールドへのReflectionと毎フレームpollingを削除
- SymphonyMcpToolsとSceneLoader sampleを公開Query APIへ移行
- Query、Info、ViewModel、MCP出力のEditModeテストを追加
- パッケージバージョンを2.13.0へ更新

## 設計判断

G1で導入した `SceneLoadRequest` が「何をどの優先度でロードするか」という命令を表し、今回追加した `SceneLoadInfo` が「現在どの状態か」という観測結果を表します。シーン名と優先度をValue Objectへまとめつつ、要求と状態の責務を分離しました。

既存の公開シグネチャと `SceneLoadState` は維持しており、破壊的変更はありません。

## 検証

- Unity compile: Error 0 / Warning 0
- EditMode: 102 passed
- PlayMode: 4 passed
- Domain Reload / Scene Reload無効のPlay Mode開始・終了を2往復し、終了後にScene Loaderが未初期化へ戻ることを確認
- Symphony Administratorでシーン名、状態、優先度、進捗、Active状態の表示を確認
