### PR TITLE
Service LocateのQueryとViewModelを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.15.0] - 2026-08-03
+### Add
+- 登録キー、payload、登録方式を取得時点の不変値として返す公開`ServiceRegistrationInfo`を追加した。`ServiceLocator.GetRegistrationInfos()`で登録一覧を型名順に取得でき、`TryGetRegistrationInfo`で既知の型を点検索できる。
+- `ServiceLocateQuery`の点検索、一覧順、表示名、スナップショット性と、`ServiceLocateViewModel`の初期値、状態変更通知、通知抑制、購読解除を検証するEditModeテストを追加した。
+
+### Change
+- Service Locatorの読み取り経路を内部`ServiceLocateQuery`へ集約し、公開API向け`ServiceRegistrationInfo`とView向け`ServiceLocateDto`を分離した。`ServiceLocator`はRegistry／Entityを直接読まず、状態照会をQueryへ転送する。
+- `ServiceLocatorWindow`を`ServiceLocateViewModel`の読み取り専用ReactiveProperty購読へ変更した。Editor更新ごとの登録一覧pollingを廃止し、状態変更時だけ型名、payload名、登録方式を再描画する。Play Mode終了時に購読を解除するため、Domain Reload無効でも前回の表示状態を残さない。
+- `SymphonyMcpTools.GetServiceLocatorJson()`を公開`ServiceRegistrationInfo`から生成するようにした。既存JSONフィールドを維持し、Componentでは記録された登録方式、Component以外では従来どおりLocatorを実効値として返す。
+
+### Fix
+- Play Mode終了時にOrchestratorがService Locatorを解放した後で`SymphonyLocate.OnDisable()`が登録状態を照会し、`SymphonyNotInitializedException`を記録する問題を修正した。未初期化時は解除処理をスキップし、Domain Reload無効で2回往復して終了時エラーと登録残留がないことを確認した。
+
 ## [2.14.0] - 2026-08-02
 ### Add
 - 重複登録で失敗した候補の所有権を呼び出し側へ残す通常の`RegisterInstance`に加え、候補を明示的に自動解放する`RegisterInstanceWithAutoDispose`のgeneric／`Type` overloadを追加した。

--- a/Documentation~/AgentUsage.md
+++ b/Documentation~/AgentUsage.md
@@ -30,6 +30,7 @@
 - 通常の`RegisterInstance`がfalseの場合も候補の所有権は呼び出し側に残る。型重複時に候補を自動解放してよい場合だけ`RegisterInstanceWithAutoDispose`へ所有権を移す。
 - `LocateType.Locator`は参照だけを登録する。`LocateType.Singleton`はComponentを管理オブジェクト配下へ移動するため、シーンローカルなオブジェクトには使わない。
 - 任意依存は`TryGetInstance<T>`、nullを許容する既存コードは`GetInstance<T>`、必須依存は`GetRequiredInstance<T>`を使う。
+- 登録中の型と登録方式を一覧で調べる場合は`GetRegistrationInfos()`、既知の型だけを調べる場合は`TryGetRegistrationInfo(Type, out ...)`を使う。返る`ServiceRegistrationInfo`は取得時点のスナップショットとして扱う。
 - `GetInstanceAsync<T>`の期限超過は`TimeoutException`、呼び出し側キャンセルは`OperationCanceledException`。`TryGetInstanceAsync<T>`がfalseへ変換するのは期限超過だけ。
 - `SceneLoader`が自動注入するのはロードしたシーンのルートにある`IInjectable<T...>`。実行時`Instantiate`したオブジェクトには`ServiceInjector.Inject(...)`を手動で呼ぶ。
 

--- a/Documentation~/Architecture.md
+++ b/Documentation~/Architecture.md
@@ -79,6 +79,14 @@ classDiagram
         RegisterInstanceWithAutoDispose()
         UnregisterInstance()
         GetRequiredInstance()
+        GetRegistrationInfos()
+        TryGetRegistrationInfo()
+    }
+    class ServiceRegistrationInfo {
+        <<readonly struct>>
+        ServiceType
+        Instance
+        LocateType
     }
     class ServiceInjector {
         <<static>>
@@ -148,6 +156,7 @@ classDiagram
     }
 
     ServiceInjector ..> ServiceLocator : 登録済み依存を取得
+    ServiceLocator --> ServiceRegistrationInfo : 登録状態のスナップショット
     ServiceInjector --> IInjectable : 注入
     SceneLoader --> SceneLoadRequest : ロード対象と優先度
     SceneLoader --> SceneLoadInfo : 追跡状態のスナップショット
@@ -176,18 +185,26 @@ flowchart LR
 
 `SceneLoadQuery`だけがRegistry／Entityを読み取り、利用側には`SceneLoadInfo`、Viewには内部Dtoを返します。`SceneLoaderWindow`はViewModelを購読し、RuntimeのRegistryやEntityを直接参照しません。
 
-Service LocateのRuntime内部では、登録単位、処理順、Unity所有処理を分離しています。
+Service LocateのRuntime内部では、登録Command、読み取り変換、表示状態、Unity所有処理を分離しています。
 
 ```mermaid
 flowchart LR
-    Locator["ServiceLocator"] --> Service["ServiceLocateService"]
+    Locator["ServiceLocator"] -->|Command| Service["ServiceLocateService"]
     Service --> Registry["ServiceLocateRegistry"]
     Registry --> Entity["ServiceRegistrationEntity"]
+    Locator -->|Query| Query["ServiceLocateQuery"]
+    Query --> Registry
+    Query --> Info["ServiceRegistrationInfo"]
+    Query --> Dto["ServiceLocateDto"]
+    Service -->|状態変更event| ViewModel["ServiceLocateViewModel"]
+    ViewModel -->|ReactiveProperty| Window["ServiceLocatorWindow"]
     Service --> HostContract["IServiceHost"]
     Host["ServiceHostComponent"] --> HostContract
     Host --> Unity["Component / Transform / Destroy"]
     Orchestrator["SymphonyOrchestrator"] -->|生成・注入| Host
 ```
+
+`ServiceLocateQuery`だけがRegistry／Entityを読み取り、利用側には`ServiceRegistrationInfo`、Viewには内部Dtoを返します。`ServiceLocatorWindow`はViewModelを購読し、登録状態が変わったときだけ再描画します。
 
 通常登録が型重複で失敗しても候補payloadを解放しません。`RegisterInstanceWithAutoDispose`を選んだ場合だけ、失敗した候補を`ServiceHostComponent`が`IDisposable`またはComponentとして解放します。RegistryとEntityはUnity APIを参照しません。
 

--- a/Editor/Administrator/SymphonyAdministrator.cs
+++ b/Editor/Administrator/SymphonyAdministrator.cs
@@ -25,7 +25,6 @@ namespace SymphonyFrameWork.Editor
         private void Update()
         {
             _pauseWindow?.Update();
-            _serviceLocatorWindow?.Update();
             _saveDataRegistryWindow?.Update();
         }
 
@@ -54,8 +53,10 @@ namespace SymphonyFrameWork.Editor
         private void OnDisable()
         {
             EditorApplication.update -= Update;
+            _serviceLocatorWindow?.Dispose();
             _sceneLoaderWindow?.Dispose();
             _saveDataRegistryWindow?.Dispose();
+            _serviceLocatorWindow = null;
             _sceneLoaderWindow = null;
             _saveDataRegistryWindow = null;
         }

--- a/Editor/Administrator/UITK/CS/ServiceLocatorWindow.cs
+++ b/Editor/Administrator/UITK/CS/ServiceLocatorWindow.cs
@@ -5,17 +5,17 @@ using System.Threading.Tasks;
 using SymphonyFrameWork.System.ServiceLocate;
 using SymphonyFrameWork.Utility;
 
-using UnityEngine;
+using UnityEditor;
 using UnityEngine.UIElements;
 
 namespace SymphonyFrameWork.Editor
 {
     /// <summary> Service Locatorの登録状態とデバッグログ設定を表示する管理パネル。 </summary>
     [UxmlElement]
-    public sealed partial class ServiceLocatorWindow : SymphonyVisualElement
+    public sealed partial class ServiceLocatorWindow :
+        SymphonyVisualElement,
+        IDisposable
     {
-        private ListView _locateList;
-
         /// <summary> 管理パネル用UXMLの非同期初期化を開始する。 </summary>
         public ServiceLocatorWindow() : base(
             SymphonyAdministrator.UITK_UXML_PATH + "ServiceLocatorWindow.uxml",
@@ -23,91 +23,179 @@ namespace SymphonyFrameWork.Editor
             LoadType.AssetDataBase)
         { }
 
+        private IDisposable _registrationSubscription;
+        private List<ServiceLocateDto> _registrationItems = new();
+        private ListView _locateList;
+        private bool _isDisposed;
+
+        /// <summary> ViewModelとEditor callbackの購読を解除する。 </summary>
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            EditorApplication.playModeStateChanged -= PlayModeStateChangedHandler;
+            EditorApplication.delayCall -= DelayedBindViewModel;
+            UnbindViewModel();
+        }
+
         /// <summary> 登録一覧とService Locatorのログ設定Toggleを構成する。 </summary>
+        /// <param name="container"> UXMLから生成されたルート要素。 </param>
+        /// <returns> 同期的に完了する初期化処理。 </returns>
         protected override ValueTask Initialize_S(VisualElement container)
         {
+            if (_isDisposed)
+            {
+                return default;
+            }
+
             _locateList = container.Q<ListView>("locate-list");
-
             _locateList.makeItem = () => new Label();
-
-            // 項目のバインド（データを UI に反映）
             _locateList.bindItem = (element, index) =>
             {
-                var kvp =
-                    (KeyValuePair<Type, object>)_locateList.itemsSource[index];
-                if (kvp.Value is UnityEngine.Object unityObject && unityObject == null)
-                {
-                    (element as Label).text = $"type : {kvp.Key.Name}\nobj : (Destroyed)";
-                    return;
-                }
-                // Componentの場合のみnameプロパティにアクセス
-                string objName = (kvp.Value is Component component) ? component.name : kvp.Value.GetType().Name;
-                (element as Label).text = $"type : {kvp.Key.Name}\nobj : {objName}";
+                ServiceLocateDto registration = _registrationItems[index];
+                (element as Label).text =
+                    $"type : {registration.ServiceTypeName}\n"
+                    + $"obj : {registration.InstanceName}\n"
+                    + $"locate type : {registration.LocateType}";
             };
-            
-            // データのセット
-            _locateList.itemsSource = GetLocateList();
-
-            // 選択タイプの設定
+            _locateList.itemsSource = _registrationItems;
             _locateList.selectionType = SelectionType.None;
 
-            //ログのコンフィグを初期化
-            SymphonyUserSettingConfig config =
-                SymphonyEditorConfigLocator.GetConfig<SymphonyUserSettingConfig>();
-
-            var setInstanceLogActive = container.Q<Toggle>("set_instance-log-active");
-            InitializeToggle(setInstanceLogActive,
-                config.IsServiceLocatorSetInstanceLogEnabled,
-                value => config.IsServiceLocatorSetInstanceLogEnabled = value);
-
-            var getInstanceLogActive = container.Q<Toggle>("get_instance-log-active");
-            InitializeToggle(getInstanceLogActive,
-                config.IsServiceLocatorGetInstanceLogEnabled,
-                value => config.IsServiceLocatorGetInstanceLogEnabled = value);
-
-            var destroyInstanceLogActive = container.Q<Toggle>("destroy_instance-log-active");
-            InitializeToggle(destroyInstanceLogActive,
-                config.IsServiceLocatorDestroyInstanceLogEnabled,
-                value => config.IsServiceLocatorDestroyInstanceLogEnabled = value);
-
+            InitializeLogToggles(container);
+            EditorApplication.playModeStateChanged += PlayModeStateChangedHandler;
+            BindViewModel();
             return default;
         }
 
-        /// <summary> 表示用に登録payloadの変更不能なスナップショットをListへ変換する。 </summary>
-        private List<KeyValuePair<Type, object>> GetLocateList()
+        /// <summary> Play Mode遷移に合わせて現在のViewModelへ接続し直す。 </summary>
+        /// <param name="state"> 遷移後のPlay Mode状態。 </param>
+        private void PlayModeStateChangedHandler(PlayModeStateChange state)
         {
-            IReadOnlyDictionary<Type, object> registeredInstances =
-                ServiceLocator.IsInitialized
-                    ? ServiceLocator.RegisteredInstances
-                    : null;
-
-            return registeredInstances != null
-                ? new List<KeyValuePair<Type, object>>(registeredInstances)
-                : new List<KeyValuePair<Type, object>>();
-        }
-
-        /// <summary> 登録一覧を最新のService Locator状態で再構築する。 </summary>
-        public void Update()
-        {
-            if (_locateList != null)
+            switch (state)
             {
-                _locateList.itemsSource = GetLocateList();
-                _locateList.Rebuild();
+                case PlayModeStateChange.EnteredPlayMode:
+                    EditorApplication.delayCall -= DelayedBindViewModel;
+                    EditorApplication.delayCall += DelayedBindViewModel;
+                    break;
+
+                case PlayModeStateChange.ExitingPlayMode:
+                case PlayModeStateChange.EnteredEditMode:
+                    EditorApplication.delayCall -= DelayedBindViewModel;
+                    UnbindViewModel();
+                    ApplyRegistrations(Array.Empty<ServiceLocateDto>());
+                    break;
             }
         }
 
-        /// <summary> UserSettingsへ保存されるログ設定Toggleを初期化する。 </summary>
-        private static void InitializeToggle(Toggle toggle, bool currentValue, Action<bool> valueSetter)
+        /// <summary> Service Locator初期化後のEditor callbackでViewModelへ接続する。 </summary>
+        private void DelayedBindViewModel()
         {
-            if (toggle != null)
+            EditorApplication.delayCall -= DelayedBindViewModel;
+            BindViewModel();
+        }
+
+        /// <summary> 現在のService Locate ViewModelへ接続する。 </summary>
+        private void BindViewModel()
+        {
+            UnbindViewModel();
+
+            if (_isDisposed
+                || !EditorApplication.isPlaying
+                || !ServiceLocator.IsInitialized)
             {
-                toggle.value = currentValue;
-                toggle.RegisterValueChangedCallback(changeEvent =>
-                {
-                    valueSetter(changeEvent.newValue);
-                    PackageInitializer.ApplyServiceLocateLogOptions();
-                });
+                ApplyRegistrations(Array.Empty<ServiceLocateDto>());
+                return;
             }
+
+            ServiceLocateViewModel viewModel = ServiceLocator.CurrentViewModel;
+            if (viewModel == null)
+            {
+                ApplyRegistrations(Array.Empty<ServiceLocateDto>());
+                return;
+            }
+
+            _registrationSubscription =
+                viewModel.Registrations.Subscribe(ApplyRegistrations);
+        }
+
+        /// <summary> 現在のViewModel購読を解除する。 </summary>
+        private void UnbindViewModel()
+        {
+            _registrationSubscription?.Dispose();
+            _registrationSubscription = null;
+        }
+
+        /// <summary> 最新Dto一覧をListViewへ反映する。 </summary>
+        /// <param name="serviceDtos"> ViewModelが公開した変更不能なDto一覧。 </param>
+        private void ApplyRegistrations(
+            IReadOnlyList<ServiceLocateDto> serviceDtos)
+        {
+            _registrationItems = serviceDtos == null
+                ? new List<ServiceLocateDto>()
+                : new List<ServiceLocateDto>(serviceDtos);
+
+            if (_locateList == null)
+            {
+                return;
+            }
+
+            _locateList.itemsSource = _registrationItems;
+            _locateList.Rebuild();
+        }
+
+        /// <summary> User Settingsへ保存されるログ設定Toggleを初期化する。 </summary>
+        /// <param name="container"> Toggleを所有するルート要素。 </param>
+        private static void InitializeLogToggles(VisualElement container)
+        {
+            SymphonyUserSettingConfig config =
+                SymphonyEditorConfigLocator.GetConfig<SymphonyUserSettingConfig>();
+
+            Toggle setInstanceLogActive =
+                container.Q<Toggle>("set_instance-log-active");
+            InitializeToggle(
+                setInstanceLogActive,
+                config.IsServiceLocatorSetInstanceLogEnabled,
+                value => config.IsServiceLocatorSetInstanceLogEnabled = value);
+
+            Toggle getInstanceLogActive =
+                container.Q<Toggle>("get_instance-log-active");
+            InitializeToggle(
+                getInstanceLogActive,
+                config.IsServiceLocatorGetInstanceLogEnabled,
+                value => config.IsServiceLocatorGetInstanceLogEnabled = value);
+
+            Toggle destroyInstanceLogActive =
+                container.Q<Toggle>("destroy_instance-log-active");
+            InitializeToggle(
+                destroyInstanceLogActive,
+                config.IsServiceLocatorDestroyInstanceLogEnabled,
+                value => config.IsServiceLocatorDestroyInstanceLogEnabled = value);
+        }
+
+        /// <summary> User Settingsへ保存されるログ設定Toggleを初期化する。 </summary>
+        /// <param name="toggle"> 初期化するToggle。 </param>
+        /// <param name="currentValue"> 現在の設定値。 </param>
+        /// <param name="valueSetter"> 変更後の値を保存する処理。 </param>
+        private static void InitializeToggle(
+            Toggle toggle,
+            bool currentValue,
+            Action<bool> valueSetter)
+        {
+            if (toggle == null)
+            {
+                return;
+            }
+
+            toggle.value = currentValue;
+            toggle.RegisterValueChangedCallback(changeEvent =>
+            {
+                valueSetter(changeEvent.newValue);
+                PackageInitializer.ApplyServiceLocateLogOptions();
+            });
         }
     }
 }

--- a/Editor/Debug/SymphonyMcpTools.cs
+++ b/Editor/Debug/SymphonyMcpTools.cs
@@ -40,13 +40,14 @@ namespace SymphonyFrameWork.Editor.Debugger
                     });
                 }
 
-                IReadOnlyDictionary<Type, object> registeredInstances = ServiceLocator.RegisteredInstances;
-                var registrations = registeredInstances
-                    .Select(pair => new
+                IReadOnlyList<ServiceRegistrationInfo> registrationInfos =
+                    ServiceLocator.GetRegistrationInfos();
+                var registrations = registrationInfos
+                    .Select(registrationInfo => new
                     {
-                        typeName = GetTypeName(pair.Key),
-                        effectiveLocateType = GetLocateType(pair.Value).ToString(),
-                        instanceName = GetInstanceName(pair.Value)
+                        typeName = GetTypeName(registrationInfo.ServiceType),
+                        effectiveLocateType = GetLocateType(registrationInfo).ToString(),
+                        instanceName = GetInstanceName(registrationInfo.Instance)
                     })
                     .ToArray();
 
@@ -197,23 +198,18 @@ namespace SymphonyFrameWork.Editor.Debugger
         }
 
         /// <summary>
-        ///     登録済みインスタンスに実際に適用されている登録方式を判定する。
-        ///     Service Locatorは登録時に渡された<see cref="LocateType"/>を保持しないため、
-        ///     これは記録値ではなく現在の状態から導いた**実効値**である。
+        ///     登録情報から診断上の実効登録方式を判定する。
         ///     Componentでない登録は<see cref="LocateType.Singleton"/>を指定しても
         ///     階層移動が起きず両者の挙動が同じになるため、常にLocatorとして扱う。
         /// </summary>
-        /// <param name="instance"> 登録済みインスタンス。 </param>
-        /// <returns> ComponentがLocator所有階層にある場合はSingleton、それ以外はLocator。 </returns>
-        private static LocateType GetLocateType(object instance)
+        /// <param name="registrationInfo"> 登録方式とpayloadを持つ公開スナップショット。 </param>
+        /// <returns> Componentでは記録された登録方式、それ以外はLocator。 </returns>
+        private static LocateType GetLocateType(
+            ServiceRegistrationInfo registrationInfo)
         {
-            Transform singletonRoot = ServiceLocator.SingletonRoot;
-            if (instance is Component component
-                && component != null
-                && singletonRoot != null
-                && component.transform.parent == singletonRoot)
+            if (registrationInfo.Instance is Component)
             {
-                return LocateType.Singleton;
+                return registrationInfo.LocateType;
             }
 
             return LocateType.Locator;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **2.14.0**
+- 現在のバージョン: **2.15.0**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること
@@ -136,6 +136,17 @@ GameSession awaited = await ServiceLocator.GetInstanceAsync<GameSession>(
 ServiceLocator.RegisterInstanceWithAutoDispose(
     newSession,
     LocateType.Singleton);
+```
+
+登録中の型、payload、登録方式を一覧で診断する場合は、取得時点の不変な`ServiceRegistrationInfo`を使います。既知の型だけを調べる場合は`TryGetRegistrationInfo`を使えます。
+
+```csharp
+foreach (ServiceRegistrationInfo registration
+         in ServiceLocator.GetRegistrationInfos())
+{
+    Debug.Log(
+        $"{registration.ServiceType.Name}: {registration.LocateType}");
+}
 ```
 
 シーンロード時の自動注入には`IInjectable<T...>`、実行時に生成したオブジェクトへの手動注入には`ServiceInjector.Inject(...)`を使います。

--- a/Runtime/Component/SymphonyLocate.cs
+++ b/Runtime/Component/SymphonyLocate.cs
@@ -47,15 +47,13 @@ namespace SymphonyFrameWork.Utility
         {
             if (!_autoUnregister) { return; }
             if (_target == null) { return; }
+            if (!ServiceLocator.IsInitialized) { return; }
 
-            if (_target != null)
-            {
-                // 別の所有者が解除済みの場合に重複解除しない。
-                bool isExist = ServiceLocator.IsExistInstance(_targetType);
-                if (!isExist) { return; }
+            // 別の所有者が解除済みの場合に重複解除しない。
+            bool isExist = ServiceLocator.IsExistInstance(_targetType);
+            if (!isExist) { return; }
 
-                ServiceLocator.UnregisterInstance(_targetType);
-            }
+            ServiceLocator.UnregisterInstance(_targetType);
         }
 
         /// <summary> インスペクターで指定された対象の実行時型を同期する。 </summary>

--- a/Runtime/System/ServiceLocator/Internal/Adaptor.meta
+++ b/Runtime/System/ServiceLocator/Internal/Adaptor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6baf79d83be368d4cbab26bef12b3095
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateDto.cs
+++ b/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateDto.cs
@@ -1,0 +1,69 @@
+﻿using System;
+
+namespace SymphonyFrameWork.System.ServiceLocate
+{
+    /// <summary> Service Locatorの表示に必要な不変の更新値。 </summary>
+    internal readonly struct ServiceLocateDto : IEquatable<ServiceLocateDto>
+    {
+        /// <summary> 表示に必要な値を指定して更新値を生成する。 </summary>
+        /// <param name="serviceTypeName"> 登録キーの短い型名。 </param>
+        /// <param name="instanceName"> 登録payloadの表示名。 </param>
+        /// <param name="locateType"> 登録時に指定された登録方式。 </param>
+        internal ServiceLocateDto(
+            string serviceTypeName,
+            string instanceName,
+            LocateType locateType)
+        {
+            ServiceTypeName = serviceTypeName;
+            InstanceName = instanceName;
+            LocateType = locateType;
+        }
+
+        /// <summary> 登録キーの短い型名。 </summary>
+        internal string ServiceTypeName { get; }
+
+        /// <summary> 登録payloadの表示名。 </summary>
+        internal string InstanceName { get; }
+
+        /// <summary> 登録時に指定された登録方式。 </summary>
+        internal LocateType LocateType { get; }
+
+        /// <summary> 指定した更新値と同値か判定する。 </summary>
+        /// <param name="other"> 比較対象。 </param>
+        /// <returns> すべての値が一致する場合はtrue。 </returns>
+        public bool Equals(ServiceLocateDto other) =>
+            string.Equals(
+                ServiceTypeName,
+                other.ServiceTypeName,
+                StringComparison.Ordinal)
+            && string.Equals(
+                InstanceName,
+                other.InstanceName,
+                StringComparison.Ordinal)
+            && LocateType == other.LocateType;
+
+        /// <summary> 指定したオブジェクトと同値か判定する。 </summary>
+        /// <param name="obj"> 比較対象。 </param>
+        /// <returns> 同値のServiceLocateDtoの場合はtrue。 </returns>
+        public override bool Equals(object obj) =>
+            obj is ServiceLocateDto other && Equals(other);
+
+        /// <summary> 更新値の全値に基づくハッシュコードを返す。 </summary>
+        /// <returns> ハッシュコード。 </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = ServiceTypeName != null
+                    ? StringComparer.Ordinal.GetHashCode(ServiceTypeName)
+                    : 0;
+                hashCode = (hashCode * 397)
+                    ^ (InstanceName != null
+                        ? StringComparer.Ordinal.GetHashCode(InstanceName)
+                        : 0);
+                hashCode = (hashCode * 397) ^ (int)LocateType;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateDto.cs.meta
+++ b/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateDto.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5929d33facbd5c6429d28cc002566e6e

--- a/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateQuery.cs
+++ b/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateQuery.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+namespace SymphonyFrameWork.System.ServiceLocate
+{
+    /// <summary> Service RegistryとEntityを公開InfoまたはView用Dtoへ変換する。 </summary>
+    internal sealed class ServiceLocateQuery
+    {
+        /// <summary> 読み取り対象のRegistryを指定してQueryを生成する。 </summary>
+        /// <param name="registry"> Service Entityを所有するRegistry。 </param>
+        internal ServiceLocateQuery(ServiceLocateRegistry registry)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        private readonly ServiceLocateRegistry _registry;
+
+        /// <summary> 指定型の登録payloadを取得する。 </summary>
+        /// <param name="serviceType"> 検索する登録キー。 </param>
+        /// <param name="instance"> 取得できたpayload。 </param>
+        /// <returns> 登録payloadを取得できた場合はtrue。 </returns>
+        internal bool TryGetInstance(Type serviceType, out object instance)
+        {
+            if (!_registry.TryGet(
+                serviceType,
+                out ServiceRegistrationEntity entity))
+            {
+                instance = null;
+                return false;
+            }
+
+            instance = entity.Instance;
+            return true;
+        }
+
+        /// <summary> 指定型が登録済みか判定する。 </summary>
+        /// <param name="serviceType"> 検索する登録キー。 </param>
+        /// <returns> 登録済みの場合はtrue。 </returns>
+        internal bool Contains(Type serviceType) =>
+            _registry.Contains(serviceType);
+
+        /// <summary> 指定型の公開スナップショットを取得する。 </summary>
+        /// <param name="serviceType"> 検索する登録キー。 </param>
+        /// <param name="registrationInfo"> 取得できた公開スナップショット。 </param>
+        /// <returns> 登録中のServiceを取得できた場合はtrue。 </returns>
+        internal bool TryGetInfo(
+            Type serviceType,
+            out ServiceRegistrationInfo registrationInfo)
+        {
+            if (!_registry.TryGet(
+                serviceType,
+                out ServiceRegistrationEntity entity))
+            {
+                registrationInfo = default;
+                return false;
+            }
+
+            registrationInfo = CreateInfo(entity);
+            return true;
+        }
+
+        /// <summary> 登録中Serviceの公開スナップショット一覧を返す。 </summary>
+        /// <returns> 型の完全名を基準にordinal昇順で並んだ変更不能な一覧。 </returns>
+        internal IReadOnlyList<ServiceRegistrationInfo> GetInfos()
+        {
+            List<ServiceRegistrationEntity> entities = GetSortedEntities();
+            var registrationInfos = new ServiceRegistrationInfo[entities.Count];
+
+            for (int i = 0; i < entities.Count; i++)
+            {
+                registrationInfos[i] = CreateInfo(entities[i]);
+            }
+
+            return Array.AsReadOnly(registrationInfos);
+        }
+
+        /// <summary> 登録中ServiceのView用更新値一覧を返す。 </summary>
+        /// <returns> 型の完全名を基準にordinal昇順で並んだ変更不能な一覧。 </returns>
+        internal IReadOnlyList<ServiceLocateDto> GetDtos()
+        {
+            List<ServiceRegistrationEntity> entities = GetSortedEntities();
+            var serviceDtos = new ServiceLocateDto[entities.Count];
+
+            for (int i = 0; i < entities.Count; i++)
+            {
+                ServiceRegistrationEntity entity = entities[i];
+                serviceDtos[i] = new ServiceLocateDto(
+                    entity.ServiceType.Name,
+                    GetInstanceName(entity.Instance),
+                    entity.LocateType);
+            }
+
+            return Array.AsReadOnly(serviceDtos);
+        }
+
+        /// <summary> Entityから公開スナップショットを生成する。 </summary>
+        /// <param name="entity"> 変換元Entity。 </param>
+        /// <returns> 公開スナップショット。 </returns>
+        private static ServiceRegistrationInfo CreateInfo(
+            ServiceRegistrationEntity entity) =>
+            new(
+                entity.ServiceType,
+                entity.Instance,
+                entity.LocateType);
+
+        /// <summary> 登録payloadの表示名を取得する。 </summary>
+        /// <param name="instance"> 登録されたpayload。 </param>
+        /// <returns> Unity Object名または実行時型名。 </returns>
+        private static string GetInstanceName(object instance)
+        {
+            if (instance is Component component)
+            {
+                return component == null
+                    ? "(Destroyed)"
+                    : component.name;
+            }
+
+            if (instance is UnityEngine.Object unityObject)
+            {
+                return unityObject == null
+                    ? "(Destroyed)"
+                    : unityObject.name;
+            }
+
+            return instance?.GetType().Name;
+        }
+
+        /// <summary> RegistryのEntityを型の完全名を基準にordinal昇順で複製する。 </summary>
+        /// <returns> 並べ替え済みEntity一覧。 </returns>
+        private List<ServiceRegistrationEntity> GetSortedEntities()
+        {
+            var entities = new List<ServiceRegistrationEntity>(
+                _registry.Entities.Values);
+            entities.RemoveAll(entity => !entity.IsRegistered);
+            entities.Sort(CompareEntities);
+            return entities;
+        }
+
+        /// <summary> 2つのEntityを登録キーの完全名で比較する。 </summary>
+        /// <param name="left"> 左辺のEntity。 </param>
+        /// <param name="right"> 右辺のEntity。 </param>
+        /// <returns> 比較結果。 </returns>
+        private static int CompareEntities(
+            ServiceRegistrationEntity left,
+            ServiceRegistrationEntity right) =>
+            StringComparer.Ordinal.Compare(
+                GetTypeName(left.ServiceType),
+                GetTypeName(right.ServiceType));
+
+        /// <summary> 型の完全名を取得し、完全名が無い型では短い型名を返す。 </summary>
+        /// <param name="serviceType"> 表示する型。 </param>
+        /// <returns> 型の完全名または短い型名。 </returns>
+        private static string GetTypeName(Type serviceType) =>
+            serviceType.FullName ?? serviceType.Name;
+    }
+}

--- a/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateQuery.cs.meta
+++ b/Runtime/System/ServiceLocator/Internal/Adaptor/ServiceLocateQuery.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fbfbae9beca8af4fb31b4e262f15507

--- a/Runtime/System/ServiceLocator/Internal/Application/ServiceLocateRegistry.cs
+++ b/Runtime/System/ServiceLocator/Internal/Application/ServiceLocateRegistry.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace SymphonyFrameWork.System.ServiceLocate
 {
     /// <summary> 型をキーにService Registration Entityと登録待機callbackを所有する。 </summary>
     internal sealed class ServiceLocateRegistry
     {
+        /// <summary> Queryが読み取る登録Entity一覧。 </summary>
+        internal IReadOnlyDictionary<Type, ServiceRegistrationEntity> Entities =>
+            _entities;
+
         /// <summary> 型とpayloadを重複なしで登録する。 </summary>
         /// <param name="serviceType"> 登録キーとして使用する型。 </param>
         /// <param name="instance"> 登録するpayload。 </param>
@@ -66,22 +69,6 @@ namespace SymphonyFrameWork.System.ServiceLocate
 
             entity.Unregister();
             return true;
-        }
-
-        /// <summary> 登録payload一覧の変更不能なスナップショットを返す。 </summary>
-        /// <returns> 型をキーとするpayload一覧。 </returns>
-        internal IReadOnlyDictionary<Type, object> GetInstancesSnapshot()
-        {
-            var snapshot = new Dictionary<Type, object>(_entities.Count);
-            foreach (KeyValuePair<Type, ServiceRegistrationEntity> pair in _entities)
-            {
-                if (pair.Value.IsRegistered)
-                {
-                    snapshot.Add(pair.Key, pair.Value.Instance);
-                }
-            }
-
-            return new ReadOnlyDictionary<Type, object>(snapshot);
         }
 
         /// <summary> 指定型の登録後に引数なしで実行するcallbackを追加する。 </summary>

--- a/Runtime/System/ServiceLocator/Internal/Infrastructure/ServiceHostComponent.cs
+++ b/Runtime/System/ServiceLocator/Internal/Infrastructure/ServiceHostComponent.cs
@@ -7,9 +7,6 @@ namespace SymphonyFrameWork.System.ServiceLocate
     /// <summary> Singleton Componentの所有とUnity Objectの解放を行う境界。 </summary>
     internal sealed class ServiceHostComponent : MonoBehaviour, IServiceHost
     {
-        /// <summary> MCP診断が既存の実効登録方式を判定するための所有先。 </summary>
-        internal Transform Root => this != null ? transform : null;
-
         /// <summary> 所有GameObjectを冪等に破棄する。 </summary>
         internal void DisposeHost()
         {
@@ -21,7 +18,7 @@ namespace SymphonyFrameWork.System.ServiceLocate
             _isDisposed = true;
             if (this != null && gameObject != null)
             {
-                Destroy(gameObject);
+                DestroyGameObject(gameObject);
             }
         }
 
@@ -70,7 +67,7 @@ namespace SymphonyFrameWork.System.ServiceLocate
             {
                 if (instance is Component component && component != null)
                 {
-                    Destroy(component.gameObject);
+                    DestroyGameObject(component.gameObject);
                     disposed = true;
                 }
             }
@@ -80,6 +77,19 @@ namespace SymphonyFrameWork.System.ServiceLocate
 
         /// <summary> Unity終了中のTransform操作を防ぐ。 </summary>
         private void OnApplicationQuit() => _isQuitting = true;
+
+        /// <summary> 実行環境に適したUnity Object破棄処理を使用する。 </summary>
+        /// <param name="target"> 破棄するGameObject。 </param>
+        private static void DestroyGameObject(GameObject target)
+        {
+            if (Application.isPlaying)
+            {
+                Destroy(target);
+                return;
+            }
+
+            DestroyImmediate(target);
+        }
 
         private bool _isDisposed;
         private bool _isQuitting;

--- a/Runtime/System/ServiceLocator/Internal/View.meta
+++ b/Runtime/System/ServiceLocator/Internal/View.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d73ba85cbb17924aa5b0beb85ca4b1e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/System/ServiceLocator/Internal/View/ServiceLocateViewModel.cs
+++ b/Runtime/System/ServiceLocator/Internal/View/ServiceLocateViewModel.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+
+using SymphonyFrameWork.Core;
+
+namespace SymphonyFrameWork.System.ServiceLocate
+{
+    /// <summary> Service Locatorの状態変更を表示用ReactivePropertyへ変換する。 </summary>
+    internal sealed class ServiceLocateViewModel : IDisposable
+    {
+        /// <summary> Queryと状態変更元Serviceを指定してViewModelを生成する。 </summary>
+        /// <param name="query"> 表示用Dtoを生成するQuery。 </param>
+        /// <param name="service"> 状態変更eventを発行するService。 </param>
+        internal ServiceLocateViewModel(
+            ServiceLocateQuery query,
+            ServiceLocateService service)
+        {
+            _query = query ?? throw new ArgumentNullException(nameof(query));
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _registrations = new ReactiveProperty<IReadOnlyList<ServiceLocateDto>>(
+                _query.GetDtos(),
+                new ServiceLocateDtoListComparer());
+            _service.OnStateChanged += StateChangedHandler;
+        }
+
+        /// <summary> 登録中Serviceの表示用更新値一覧。 </summary>
+        internal IReadOnlyReactiveProperty<IReadOnlyList<ServiceLocateDto>> Registrations =>
+            _registrations;
+
+        private readonly ServiceLocateQuery _query;
+        private readonly ServiceLocateService _service;
+        private readonly ReactiveProperty<IReadOnlyList<ServiceLocateDto>> _registrations;
+
+        private bool _isDisposed;
+
+        /// <summary> Service eventの購読とReactivePropertyを破棄する。 </summary>
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _service.OnStateChanged -= StateChangedHandler;
+            _registrations.Dispose();
+        }
+
+        /// <summary> Serviceの状態変更を最新Dto一覧へ反映する。 </summary>
+        private void StateChangedHandler()
+        {
+            _registrations.SetValue(_query.GetDtos());
+        }
+
+        /// <summary> Service Locate Dto一覧を内容で比較する。 </summary>
+        private sealed class ServiceLocateDtoListComparer :
+            IEqualityComparer<IReadOnlyList<ServiceLocateDto>>
+        {
+            /// <summary> 2つのDto一覧が同じ順序と値を持つか判定する。 </summary>
+            /// <param name="left"> 左辺の一覧。 </param>
+            /// <param name="right"> 右辺の一覧。 </param>
+            /// <returns> 内容が同じ場合はtrue。 </returns>
+            public bool Equals(
+                IReadOnlyList<ServiceLocateDto> left,
+                IReadOnlyList<ServiceLocateDto> right)
+            {
+                if (ReferenceEquals(left, right))
+                {
+                    return true;
+                }
+
+                if (left == null || right == null || left.Count != right.Count)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < left.Count; i++)
+                {
+                    if (!left[i].Equals(right[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            /// <summary> Dto一覧の内容に基づくハッシュコードを返す。 </summary>
+            /// <param name="serviceDtos"> ハッシュ化する一覧。 </param>
+            /// <returns> ハッシュコード。 </returns>
+            public int GetHashCode(IReadOnlyList<ServiceLocateDto> serviceDtos)
+            {
+                if (serviceDtos == null)
+                {
+                    return 0;
+                }
+
+                unchecked
+                {
+                    int hashCode = 17;
+                    for (int i = 0; i < serviceDtos.Count; i++)
+                    {
+                        hashCode = (hashCode * 31)
+                            ^ serviceDtos[i].GetHashCode();
+                    }
+
+                    return hashCode;
+                }
+            }
+        }
+    }
+}

--- a/Runtime/System/ServiceLocator/Internal/View/ServiceLocateViewModel.cs.meta
+++ b/Runtime/System/ServiceLocator/Internal/View/ServiceLocateViewModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9aa5374e82a2e642a3207d2b3ae52f8

--- a/Runtime/System/ServiceLocator/ServiceLocator.cs
+++ b/Runtime/System/ServiceLocator/ServiceLocator.cs
@@ -91,10 +91,10 @@ namespace SymphonyFrameWork.System.ServiceLocate
         {
             EnsureInitialized();
             if (instance == null) { return false; }
-            if (!_registry.TryGet(
+            if (!_query.TryGetInstance(
                 typeof(T),
-                out ServiceRegistrationEntity entity)
-                || !ReferenceEquals(instance, entity.Instance))
+                out object registeredInstance)
+                || !ReferenceEquals(instance, registeredInstance))
             {
                 return false;
             }
@@ -167,7 +167,7 @@ namespace SymphonyFrameWork.System.ServiceLocate
             EnsureInitialized();
             Type type = typeof(T);
 
-            if (!_registry.Contains(type))
+            if (!_query.Contains(type))
             {
                 Debug.LogWarning($"{type.Name}は登録されていません");
                 return false;
@@ -207,7 +207,33 @@ namespace SymphonyFrameWork.System.ServiceLocate
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return _registry.Contains(type);
+            return _query.Contains(type);
+        }
+
+        /// <summary> 登録中Serviceの不変なスナップショット一覧を取得する。 </summary>
+        /// <returns> 型の完全名を基準にordinal昇順で並んだ登録情報一覧。 </returns>
+        public static IReadOnlyList<ServiceRegistrationInfo> GetRegistrationInfos()
+        {
+            EnsureInitialized();
+            return _query.GetInfos();
+        }
+
+        /// <summary> 指定した型の登録情報を不変なスナップショットとして取得する。 </summary>
+        /// <param name="serviceType"> 検索する登録キー。 </param>
+        /// <param name="registrationInfo"> 取得できた登録情報。 </param>
+        /// <returns> 登録情報を取得できた場合はtrue。 </returns>
+        public static bool TryGetRegistrationInfo(
+            Type serviceType,
+            out ServiceRegistrationInfo registrationInfo)
+        {
+            EnsureInitialized();
+
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            return _query.TryGetInfo(serviceType, out registrationInfo);
         }
 
         /// <summary>
@@ -225,10 +251,10 @@ namespace SymphonyFrameWork.System.ServiceLocate
                 SymphonyDebugLogger.AddText($"ServiceLocator\n{typeof(T).Name}の取得がリクエストされました。");
             }
 #endif
-            T instance = _registry.TryGet(
+            T instance = _query.TryGetInstance(
                 typeof(T),
-                out ServiceRegistrationEntity entity)
-                ? (T)entity.Instance
+                out object registeredInstance)
+                ? (T)registeredInstance
                 : default;
             return IsAvailableInstance(instance) ? instance : default;
         }
@@ -243,10 +269,10 @@ namespace SymphonyFrameWork.System.ServiceLocate
         {
             EnsureInitialized();
 
-            T instance = _registry.TryGet(
+            T instance = _query.TryGetInstance(
                 typeof(T),
-                out ServiceRegistrationEntity entity)
-                ? (T)entity.Instance
+                out object registeredInstance)
+                ? (T)registeredInstance
                 : default;
             if (!IsAvailableInstance(instance))
             {
@@ -265,10 +291,10 @@ namespace SymphonyFrameWork.System.ServiceLocate
         public static bool TryGetInstance<T>(out T result) where T : class
         {
             EnsureInitialized();
-            result = _registry.TryGet(
+            result = _query.TryGetInstance(
                 typeof(T),
-                out ServiceRegistrationEntity entity)
-                ? (T)entity.Instance
+                out object registeredInstance)
+                ? (T)registeredInstance
                 : default;
             if (IsAvailableInstance(result))
             {
@@ -367,7 +393,7 @@ namespace SymphonyFrameWork.System.ServiceLocate
             }
 
             // 既にインスタンスが登録済みであれば、即座にアクションを実行します。
-            if (_registry.Contains(typeof(T)))
+            if (_query.Contains(typeof(T)))
             {
                 action?.Invoke();
                 return;
@@ -393,11 +419,11 @@ namespace SymphonyFrameWork.System.ServiceLocate
             }
 
             // 既にインスタンスが登録済みであれば、そのインスタンスを引数にして即座にアクションを実行します。
-            if (_registry.TryGet(
+            if (_query.TryGetInstance(
                 typeof(T),
-                out ServiceRegistrationEntity entity))
+                out object registeredInstance))
             {
-                T instance = (T)entity.Instance;
+                T instance = (T)registeredInstance;
                 action?.Invoke(instance);
                 return;
             }
@@ -409,14 +435,12 @@ namespace SymphonyFrameWork.System.ServiceLocate
         internal static bool IsInitialized =>
             _service != null
             && _registry != null
+            && _query != null
+            && _viewModel != null
             && _host != null;
 
-        /// <summary> 型をキーとする登録済みインスタンス一覧。 </summary>
-        internal static IReadOnlyDictionary<Type, object> RegisteredInstances =>
-            _registry?.GetInstancesSnapshot();
-
-        /// <summary> Singleton登録されたComponentの所有先Transform。 </summary>
-        internal static Transform SingletonRoot => _host != null ? _host.Root : null;
+        /// <summary> Compositionが生成した表示用ViewModel。 </summary>
+        internal static ServiceLocateViewModel CurrentViewModel => _viewModel;
 
         /// <summary> Compositionが生成した所有先を使用してLocator状態を初期化する。 </summary>
         /// <param name="host"> Singleton Componentの所有と解放を行うHost。 </param>
@@ -431,13 +455,18 @@ namespace SymphonyFrameWork.System.ServiceLocate
             _host = host;
             _registry = new ServiceLocateRegistry();
             _service = new ServiceLocateService(_registry, host);
+            _query = new ServiceLocateQuery(_registry);
+            _viewModel = new ServiceLocateViewModel(_query, _service);
         }
 
         /// <summary> 登録状態を消去してLocatorを未初期化状態へ戻す。 </summary>
         internal static void ResetRuntimeState()
         {
+            _viewModel?.Dispose();
             _registry?.Clear();
             _host?.DisposeHost();
+            _viewModel = null;
+            _query = null;
             _service = null;
             _registry = null;
             _host = null;
@@ -525,5 +554,7 @@ namespace SymphonyFrameWork.System.ServiceLocate
         private static ServiceHostComponent _host;
         private static ServiceLocateRegistry _registry;
         private static ServiceLocateService _service;
+        private static ServiceLocateQuery _query;
+        private static ServiceLocateViewModel _viewModel;
     }
 }

--- a/Runtime/System/ServiceLocator/ServiceRegistrationInfo.cs
+++ b/Runtime/System/ServiceLocator/ServiceRegistrationInfo.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace SymphonyFrameWork.System.ServiceLocate
+{
+    /// <summary> Service Locatorへ登録された1件の状態を表す不変なスナップショット。 </summary>
+    public readonly struct ServiceRegistrationInfo : IEquatable<ServiceRegistrationInfo>
+    {
+        /// <summary> Queryが抽出した登録状態からスナップショットを生成する。 </summary>
+        /// <param name="serviceType"> 登録キーとして使用された型。 </param>
+        /// <param name="instance"> 登録されたpayload。 </param>
+        /// <param name="locateType"> 登録時に指定された登録方式。 </param>
+        internal ServiceRegistrationInfo(
+            Type serviceType,
+            object instance,
+            LocateType locateType)
+        {
+            ServiceType = serviceType;
+            Instance = instance;
+            LocateType = locateType;
+        }
+
+        /// <summary> 登録キーとして使用された型。 </summary>
+        public Type ServiceType { get; }
+
+        /// <summary> 登録されたpayload。 </summary>
+        public object Instance { get; }
+
+        /// <summary> 登録時に指定された登録方式。 </summary>
+        public LocateType LocateType { get; }
+
+        /// <summary> 2つの登録スナップショットが同値か判定する。 </summary>
+        /// <param name="left"> 左辺のスナップショット。 </param>
+        /// <param name="right"> 右辺のスナップショット。 </param>
+        /// <returns> 同値の場合はtrue。 </returns>
+        public static bool operator ==(
+            ServiceRegistrationInfo left,
+            ServiceRegistrationInfo right) =>
+            left.Equals(right);
+
+        /// <summary> 2つの登録スナップショットが異なるか判定する。 </summary>
+        /// <param name="left"> 左辺のスナップショット。 </param>
+        /// <param name="right"> 右辺のスナップショット。 </param>
+        /// <returns> 異なる場合はtrue。 </returns>
+        public static bool operator !=(
+            ServiceRegistrationInfo left,
+            ServiceRegistrationInfo right) =>
+            !left.Equals(right);
+
+        /// <summary> 指定した登録スナップショットと同値か判定する。 </summary>
+        /// <param name="other"> 比較対象。 </param>
+        /// <returns> 型と登録方式が等しく、payloadが同一参照の場合はtrue。 </returns>
+        public bool Equals(ServiceRegistrationInfo other) =>
+            ServiceType == other.ServiceType
+            && ReferenceEquals(Instance, other.Instance)
+            && LocateType == other.LocateType;
+
+        /// <summary> 指定したオブジェクトと同値か判定する。 </summary>
+        /// <param name="obj"> 比較対象。 </param>
+        /// <returns> 同値のServiceRegistrationInfoの場合はtrue。 </returns>
+        public override bool Equals(object obj) =>
+            obj is ServiceRegistrationInfo other && Equals(other);
+
+        /// <summary> 型、payload参照、登録方式に基づくハッシュコードを返す。 </summary>
+        /// <returns> ハッシュコード。 </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = ServiceType?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397)
+                    ^ (Instance != null
+                        ? RuntimeHelpers.GetHashCode(Instance)
+                        : 0);
+                hashCode = (hashCode * 397) ^ (int)LocateType;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Runtime/System/ServiceLocator/ServiceRegistrationInfo.cs.meta
+++ b/Runtime/System/ServiceLocator/ServiceRegistrationInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa8784e23bd58284ba80538b9e614f33

--- a/Tests/Editor/ServiceLocateQueryTests.cs
+++ b/Tests/Editor/ServiceLocateQueryTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.ServiceLocate;
+
+using UnityEngine;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> ServiceLocateQueryのInfo／Dto変換とスナップショット性を検証する。 </summary>
+    public sealed class ServiceLocateQueryTests
+    {
+        /// <summary> 登録Info一覧を型の完全名のordinal昇順で返す。 </summary>
+        [Test]
+        public void GetInfos_MultipleServices_ReturnsOrdinalOrder()
+        {
+            var registry = new ServiceLocateRegistry();
+            registry.TryRegister(
+                typeof(ZebraService),
+                new ZebraService(),
+                LocateType.Locator,
+                out _);
+            registry.TryRegister(
+                typeof(AlphaService),
+                new AlphaService(),
+                LocateType.Singleton,
+                out _);
+            registry.TryRegister(
+                typeof(MiddleService),
+                new MiddleService(),
+                LocateType.Locator,
+                out _);
+            var query = new ServiceLocateQuery(registry);
+
+            IReadOnlyList<ServiceRegistrationInfo> registrationInfos =
+                query.GetInfos();
+
+            Assert.That(
+                new[]
+                {
+                    registrationInfos[0].ServiceType,
+                    registrationInfos[1].ServiceType,
+                    registrationInfos[2].ServiceType
+                },
+                Is.EqualTo(new[]
+                {
+                    typeof(AlphaService),
+                    typeof(MiddleService),
+                    typeof(ZebraService)
+                }));
+        }
+
+        /// <summary> 点検索で登録値をInfoへ変換し、未登録型ではdefaultを返す。 </summary>
+        [Test]
+        public void TryGetInfo_RegisteredAndMissingTypes_ReturnsExpectedResults()
+        {
+            var registry = new ServiceLocateRegistry();
+            var instance = new AlphaService();
+            registry.TryRegister(
+                typeof(AlphaService),
+                instance,
+                LocateType.Singleton,
+                out _);
+            var query = new ServiceLocateQuery(registry);
+
+            bool found = query.TryGetInfo(
+                typeof(AlphaService),
+                out ServiceRegistrationInfo registrationInfo);
+            bool missing = query.TryGetInfo(
+                typeof(MiddleService),
+                out ServiceRegistrationInfo missingInfo);
+
+            Assert.That(found, Is.True);
+            Assert.That(registrationInfo.ServiceType, Is.EqualTo(typeof(AlphaService)));
+            Assert.That(registrationInfo.Instance, Is.SameAs(instance));
+            Assert.That(registrationInfo.LocateType, Is.EqualTo(LocateType.Singleton));
+            Assert.That(missing, Is.False);
+            Assert.That(missingInfo, Is.EqualTo(default(ServiceRegistrationInfo)));
+        }
+
+        /// <summary> payload取得と登録有無をRegistryから読み取る。 </summary>
+        [Test]
+        public void InstanceQueries_RegisteredType_ReturnsPayloadAndContains()
+        {
+            var registry = new ServiceLocateRegistry();
+            var instance = new AlphaService();
+            registry.TryRegister(
+                typeof(AlphaService),
+                instance,
+                LocateType.Locator,
+                out _);
+            var query = new ServiceLocateQuery(registry);
+
+            bool found = query.TryGetInstance(
+                typeof(AlphaService),
+                out object foundInstance);
+
+            Assert.That(found, Is.True);
+            Assert.That(foundInstance, Is.SameAs(instance));
+            Assert.That(query.Contains(typeof(AlphaService)), Is.True);
+            Assert.That(query.Contains(typeof(MiddleService)), Is.False);
+        }
+
+        /// <summary> 取得済みInfo／Dto一覧は後続のRegistry変更から独立している。 </summary>
+        [Test]
+        public void Snapshots_RegistryChangesAfterRead_PreservePreviousCounts()
+        {
+            var registry = new ServiceLocateRegistry();
+            registry.TryRegister(
+                typeof(AlphaService),
+                new AlphaService(),
+                LocateType.Locator,
+                out _);
+            var query = new ServiceLocateQuery(registry);
+            IReadOnlyList<ServiceRegistrationInfo> previousInfos = query.GetInfos();
+            IReadOnlyList<ServiceLocateDto> previousDtos = query.GetDtos();
+
+            registry.TryRegister(
+                typeof(MiddleService),
+                new MiddleService(),
+                LocateType.Singleton,
+                out _);
+
+            Assert.That(previousInfos, Has.Count.EqualTo(1));
+            Assert.That(previousDtos, Has.Count.EqualTo(1));
+            Assert.That(query.GetInfos(), Has.Count.EqualTo(2));
+            Assert.That(query.GetDtos(), Has.Count.EqualTo(2));
+        }
+
+        /// <summary> 通常objectの実行時型名をDtoのinstance名に使用する。 </summary>
+        [Test]
+        public void GetDtos_RegularObject_UsesRuntimeTypeName()
+        {
+            var registry = new ServiceLocateRegistry();
+            registry.TryRegister(
+                typeof(AlphaService),
+                new AlphaService(),
+                LocateType.Locator,
+                out _);
+            var query = new ServiceLocateQuery(registry);
+
+            ServiceLocateDto serviceDto = query.GetDtos()[0];
+
+            Assert.That(serviceDto.ServiceTypeName, Is.EqualTo(nameof(AlphaService)));
+            Assert.That(serviceDto.InstanceName, Is.EqualTo(nameof(AlphaService)));
+            Assert.That(serviceDto.LocateType, Is.EqualTo(LocateType.Locator));
+        }
+
+        /// <summary> 破棄済みUnity ObjectをDtoでは安全な表示文字列へ変換する。 </summary>
+        [Test]
+        public void GetDtos_DestroyedUnityObject_UsesDestroyedLabel()
+        {
+            var gameObject = new GameObject("Service Object");
+            Transform instance = gameObject.transform;
+            var registry = new ServiceLocateRegistry();
+            registry.TryRegister(
+                typeof(Transform),
+                instance,
+                LocateType.Singleton,
+                out _);
+            UnityEngine.Object.DestroyImmediate(gameObject);
+            var query = new ServiceLocateQuery(registry);
+
+            ServiceLocateDto serviceDto = query.GetDtos()[0];
+
+            Assert.That(serviceDto.InstanceName, Is.EqualTo("(Destroyed)"));
+        }
+
+        private sealed class AlphaService { }
+
+        private sealed class MiddleService { }
+
+        private sealed class ZebraService { }
+    }
+}

--- a/Tests/Editor/ServiceLocateQueryTests.cs.meta
+++ b/Tests/Editor/ServiceLocateQueryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e288a5f60755824682a52b8939e2e49

--- a/Tests/Editor/ServiceLocateRegistryTests.cs
+++ b/Tests/Editor/ServiceLocateRegistryTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using NUnit.Framework;
 
@@ -78,30 +77,6 @@ namespace SymphonyFrameWork.Tests
             Assert.That(removedEntity, Is.SameAs(entity));
             Assert.That(entity.IsRegistered, Is.False);
             Assert.That(registry.Contains(typeof(ServiceA)), Is.False);
-        }
-
-        /// <summary> payload一覧は取得後のRegistry変更から独立したスナップショットになる。 </summary>
-        [Test]
-        public void GetInstancesSnapshot_AfterRegistryChange_RemainsUnchanged()
-        {
-            var registry = new ServiceLocateRegistry();
-            registry.TryRegister(
-                typeof(ServiceA),
-                new ServiceA(),
-                LocateType.Locator,
-                out _);
-            IReadOnlyDictionary<Type, object> snapshot =
-                registry.GetInstancesSnapshot();
-
-            registry.TryRegister(
-                typeof(ServiceB),
-                new ServiceB(),
-                LocateType.Locator,
-                out _);
-
-            Assert.That(snapshot.Count, Is.EqualTo(1));
-            Assert.That(snapshot.ContainsKey(typeof(ServiceA)), Is.True);
-            Assert.That(snapshot.ContainsKey(typeof(ServiceB)), Is.False);
         }
 
         /// <summary> 2種類の登録待機callbackを登録成功時に1回だけ実行する。 </summary>
@@ -189,7 +164,7 @@ namespace SymphonyFrameWork.Tests
             registry.InvokeWaitingActions(typeof(ServiceB), new ServiceB());
 
             Assert.That(entity.IsRegistered, Is.False);
-            Assert.That(registry.GetInstancesSnapshot(), Is.Empty);
+            Assert.That(registry.Entities, Is.Empty);
             Assert.That(invocationCount, Is.Zero);
         }
 

--- a/Tests/Editor/ServiceLocateViewModelTests.cs
+++ b/Tests/Editor/ServiceLocateViewModelTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.ServiceLocate;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> ServiceLocateViewModelの初期値、通知抑制、購読解除を検証する。 </summary>
+    public sealed class ServiceLocateViewModelTests
+    {
+        /// <summary> 生成時にQueryの現在値をReactivePropertyへ反映する。 </summary>
+        [Test]
+        public void Constructor_RegisteredService_ExposesInitialDtos()
+        {
+            var registry = new ServiceLocateRegistry();
+            registry.TryRegister(
+                typeof(ServiceA),
+                new ServiceA(),
+                LocateType.Singleton,
+                out _);
+            var service = new ServiceLocateService(registry, new FakeServiceHost());
+            using var viewModel = new ServiceLocateViewModel(
+                new ServiceLocateQuery(registry),
+                service);
+
+            IReadOnlyList<ServiceLocateDto> serviceDtos =
+                viewModel.Registrations.Value;
+
+            Assert.That(serviceDtos, Has.Count.EqualTo(1));
+            Assert.That(serviceDtos[0].ServiceTypeName, Is.EqualTo(nameof(ServiceA)));
+            Assert.That(serviceDtos[0].LocateType, Is.EqualTo(LocateType.Singleton));
+        }
+
+        /// <summary> 登録、解除、破棄のService eventで最新一覧を通知する。 </summary>
+        [Test]
+        public void ServiceStateChanged_Commands_NotifyLatestDtos()
+        {
+            var registry = new ServiceLocateRegistry();
+            var service = new ServiceLocateService(registry, new FakeServiceHost());
+            using var viewModel = new ServiceLocateViewModel(
+                new ServiceLocateQuery(registry),
+                service);
+            var notifiedCounts = new List<int>();
+            using IDisposable subscription = viewModel.Registrations.Subscribe(
+                serviceDtos => notifiedCounts.Add(serviceDtos.Count),
+                notifyCurrent: false);
+
+            service.Register(
+                typeof(ServiceA),
+                new ServiceA(),
+                LocateType.Locator,
+                disposeOnFailure: false);
+            service.Unregister(typeof(ServiceA));
+            service.Register(
+                typeof(ServiceB),
+                new ServiceB(),
+                LocateType.Singleton,
+                disposeOnFailure: false);
+            service.Destroy(typeof(ServiceB));
+
+            Assert.That(notifiedCounts, Is.EqualTo(new[] { 1, 0, 1, 0 }));
+        }
+
+        /// <summary> 重複登録失敗で状態が変わらない場合は再通知しない。 </summary>
+        [Test]
+        public void Register_DuplicateType_DoesNotNotifyAgain()
+        {
+            var registry = new ServiceLocateRegistry();
+            var service = new ServiceLocateService(registry, new FakeServiceHost());
+            using var viewModel = new ServiceLocateViewModel(
+                new ServiceLocateQuery(registry),
+                service);
+            int notificationCount = 0;
+            using IDisposable subscription = viewModel.Registrations.Subscribe(
+                _ => notificationCount++,
+                notifyCurrent: false);
+
+            service.Register(
+                typeof(ServiceA),
+                new ServiceA(),
+                LocateType.Locator,
+                disposeOnFailure: false);
+            service.Register(
+                typeof(ServiceA),
+                new ServiceA(),
+                LocateType.Singleton,
+                disposeOnFailure: false);
+
+            Assert.That(notificationCount, Is.EqualTo(1));
+        }
+
+        /// <summary> Dispose後はService eventから切り離され、多重Disposeも無害になる。 </summary>
+        [Test]
+        public void Dispose_ServiceStateChanges_DoesNotNotifySubscribers()
+        {
+            var registry = new ServiceLocateRegistry();
+            var service = new ServiceLocateService(registry, new FakeServiceHost());
+            var viewModel = new ServiceLocateViewModel(
+                new ServiceLocateQuery(registry),
+                service);
+            int notificationCount = 0;
+            viewModel.Registrations.Subscribe(
+                _ => notificationCount++,
+                notifyCurrent: false);
+            viewModel.Dispose();
+
+            service.Register(
+                typeof(ServiceA),
+                new ServiceA(),
+                LocateType.Locator,
+                disposeOnFailure: false);
+
+            Assert.That(notificationCount, Is.Zero);
+            Assert.DoesNotThrow(viewModel.Dispose);
+        }
+
+        private sealed class FakeServiceHost : IServiceHost
+        {
+            /// <inheritdoc />
+            public void Attach(object instance) { }
+
+            /// <inheritdoc />
+            public void Detach(object instance) { }
+
+            /// <inheritdoc />
+            public bool DisposeInstance(object instance) => false;
+        }
+
+        private sealed class ServiceA { }
+
+        private sealed class ServiceB { }
+    }
+}

--- a/Tests/Editor/ServiceLocateViewModelTests.cs.meta
+++ b/Tests/Editor/ServiceLocateViewModelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f6e8d0e252138c468912dff5459422f

--- a/Tests/Editor/ServiceLocatorRegistrationInfoTests.cs
+++ b/Tests/Editor/ServiceLocatorRegistrationInfoTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.ServiceLocate;
+
+using UnityEngine;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> ServiceLocatorの公開登録情報Queryを検証する。 </summary>
+    public sealed class ServiceLocatorRegistrationInfoTests
+    {
+        /// <summary> 各テスト用のService HostでFacadeを初期化する。 </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            _hostObject = new GameObject("Service Locator Test Host");
+            ServiceHostComponent host =
+                _hostObject.AddComponent<ServiceHostComponent>();
+            ServiceLocator.Initialize(host);
+        }
+
+        /// <summary> static状態とテスト用GameObjectを解放する。 </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            ServiceLocator.ResetRuntimeState();
+            if (_hostObject != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_hostObject);
+            }
+        }
+
+        private GameObject _hostObject;
+
+        /// <summary> 登録一覧を型名順の公開Infoとして返す。 </summary>
+        [Test]
+        public void GetRegistrationInfos_RegisteredServices_ReturnsSortedInfos()
+        {
+            var zebra = new ZebraService();
+            var alpha = new AlphaService();
+            ServiceLocator.RegisterInstance(
+                typeof(ZebraService),
+                zebra,
+                LocateType.Locator);
+            ServiceLocator.RegisterInstance(
+                typeof(AlphaService),
+                alpha,
+                LocateType.Singleton);
+
+            IReadOnlyList<ServiceRegistrationInfo> registrationInfos =
+                ServiceLocator.GetRegistrationInfos();
+
+            Assert.That(registrationInfos, Has.Count.EqualTo(2));
+            Assert.That(registrationInfos[0].ServiceType, Is.EqualTo(typeof(AlphaService)));
+            Assert.That(registrationInfos[0].Instance, Is.SameAs(alpha));
+            Assert.That(registrationInfos[0].LocateType, Is.EqualTo(LocateType.Singleton));
+            Assert.That(registrationInfos[1].ServiceType, Is.EqualTo(typeof(ZebraService)));
+            Assert.That(registrationInfos[1].Instance, Is.SameAs(zebra));
+        }
+
+        /// <summary> 点検索は登録値を返し、未登録型とnull入力を契約どおり処理する。 </summary>
+        [Test]
+        public void TryGetRegistrationInfo_RegisteredMissingAndNullTypes_UsesTryContract()
+        {
+            var instance = new AlphaService();
+            ServiceLocator.RegisterInstance(instance, LocateType.Locator);
+
+            bool found = ServiceLocator.TryGetRegistrationInfo(
+                typeof(AlphaService),
+                out ServiceRegistrationInfo registrationInfo);
+            bool missing = ServiceLocator.TryGetRegistrationInfo(
+                typeof(ZebraService),
+                out ServiceRegistrationInfo missingInfo);
+
+            Assert.That(found, Is.True);
+            Assert.That(registrationInfo.Instance, Is.SameAs(instance));
+            Assert.That(missing, Is.False);
+            Assert.That(missingInfo, Is.EqualTo(default(ServiceRegistrationInfo)));
+            Assert.Throws<ArgumentNullException>(() =>
+                ServiceLocator.TryGetRegistrationInfo(null, out _));
+        }
+
+        private sealed class AlphaService { }
+
+        private sealed class ZebraService { }
+    }
+}

--- a/Tests/Editor/ServiceLocatorRegistrationInfoTests.cs.meta
+++ b/Tests/Editor/ServiceLocatorRegistrationInfoTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69c7a23c6d0515d499cf6948e6f5ef1d

--- a/Tests/Editor/ServiceRegistrationInfoTests.cs
+++ b/Tests/Editor/ServiceRegistrationInfoTests.cs
@@ -1,0 +1,83 @@
+﻿using NUnit.Framework;
+
+using SymphonyFrameWork.System.ServiceLocate;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> ServiceRegistrationInfoの値と参照同一性による等値契約を検証する。 </summary>
+    public sealed class ServiceRegistrationInfoTests
+    {
+        /// <summary> constructorへ渡した登録情報を保持する。 </summary>
+        [Test]
+        public void Constructor_ValidValues_StoresRegistration()
+        {
+            var instance = new ServiceA();
+
+            var registrationInfo = new ServiceRegistrationInfo(
+                typeof(ServiceA),
+                instance,
+                LocateType.Singleton);
+
+            Assert.That(registrationInfo.ServiceType, Is.EqualTo(typeof(ServiceA)));
+            Assert.That(registrationInfo.Instance, Is.SameAs(instance));
+            Assert.That(registrationInfo.LocateType, Is.EqualTo(LocateType.Singleton));
+        }
+
+        /// <summary> 同じpayload参照と値を持つInfoは等値になる。 </summary>
+        [Test]
+        public void Equality_SameReferenceAndValues_ReturnsTrue()
+        {
+            var instance = new ServiceA();
+            var left = new ServiceRegistrationInfo(
+                typeof(ServiceA),
+                instance,
+                LocateType.Locator);
+            var right = new ServiceRegistrationInfo(
+                typeof(ServiceA),
+                instance,
+                LocateType.Locator);
+
+            Assert.That(left.Equals(right), Is.True);
+            Assert.That(left == right, Is.True);
+            Assert.That(left != right, Is.False);
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        }
+
+        /// <summary> 値が等しい別payload参照は異なる登録として扱う。 </summary>
+        [Test]
+        public void Equality_DifferentPayloadReferences_ReturnsFalse()
+        {
+            var left = new ServiceRegistrationInfo(
+                typeof(string),
+                new string('a', 1),
+                LocateType.Locator);
+            var right = new ServiceRegistrationInfo(
+                typeof(string),
+                new string('a', 1),
+                LocateType.Locator);
+
+            Assert.That(left.Equals(right), Is.False);
+            Assert.That(left == right, Is.False);
+            Assert.That(left != right, Is.True);
+        }
+
+        /// <summary> 登録方式が異なるInfoは同じpayloadでも非等値になる。 </summary>
+        [Test]
+        public void Equality_DifferentLocateType_ReturnsFalse()
+        {
+            var instance = new ServiceA();
+            var locator = new ServiceRegistrationInfo(
+                typeof(ServiceA),
+                instance,
+                LocateType.Locator);
+            var singleton = new ServiceRegistrationInfo(
+                typeof(ServiceA),
+                instance,
+                LocateType.Singleton);
+
+            Assert.That(locator, Is.Not.EqualTo(singleton));
+        }
+
+        private sealed class ServiceA { }
+    }
+}

--- a/Tests/Editor/ServiceRegistrationInfoTests.cs.meta
+++ b/Tests/Editor/ServiceRegistrationInfoTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ec0b6dc7ba71a348b6213d46c845e16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
## 概要

Service Locateの読み取り経路をAdaptorの`ServiceLocateQuery`へ集約し、公開API・Editor Window・MCP診断がRegistryやEntityを直接読まない構成へ移行します。Round H1（内部レイヤー分離）に続くH2です。

## 変更内容

- 公開の不変スナップショット `ServiceRegistrationInfo` を追加
- 内部の `ServiceLocateQuery` / `ServiceLocateDto` / `ServiceLocateViewModel` を追加
- Symphony AdministratorのService Locator表示をViewModel購読へ変更し、非公開フィールドへのReflectionと毎フレームpollingを削除
- `SymphonyMcpTools` と Service Locator Sample を公開Query APIへ移行
- Query / Info / ViewModel / MCP出力のEditModeテストを追加
- パッケージバージョンを2.15.0へ更新

## 設計判断

`ServiceRegistrationInfo` は `readonly struct` + `IEquatable<T>` とし、`SceneLoadInfo` と同じ契約に揃えました。既存の公開シグネチャと `LocateType` は維持しており、破壊的変更はありません。公開型の改名はPhase 4へ据え置いています。

設計書: `Documentation/Designs/ServiceLocateQueryViewModel.md`（ワークスペースリポジトリ）

## 検証

- Unity compile: Error 0 / Warning 0
- EditMode: 141 passed
- PlayMode: 4 passed
- `RegisteredInstances` / `SingletonRoot` への参照が0件であること
- `Runtime` / `Core` から `UnityEditor` / `EditorPrefs` への新規違反が0件であること
