### PR TITLE
[add]SaveDataRegistryをSaveStoreへ改名（2.19.0）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.19.0] - 2026-08-04
+### Add
+- `SaveStore` を追加した。`SaveDataRegistry` と同じ公開APIを持ち、シグネチャ・例外の種類と条件・シリアライズ形式のいずれも変わらない。
+  - Round I1／I2 で内部を分割した結果、**この型はレジストリではなくストアになっていた**。実際のレジストリは `SaveDataEntryRegistry`（内部）であり、名前が役割と食い違っていたため改名した。
+
+### Deprecated
+- `SaveDataRegistry` を非推奨にした。**移行方法**: `SaveDataRegistry` を `SaveStore` へ置換する。それ以外の変更は不要。**3.0.0 で削除する。**
+  - 旧型は `SaveStore` へ転送するだけのFacadeとして残るため、既存コードはコンパイルが通り、`CS0618` の警告で移行先が案内される。
+  - `SaveDataRegistryEntryInfo` と Editor の `SaveDataRegistryWindow` は本バージョンでは改名しない。`GetEntries()` の戻り値要素型を変えると `IReadOnlyList<T>` が変換できず破壊的になるため、3.0.0 でまとめて扱う。
+
 ## [2.18.1] - 2026-08-04
 ### Change
 - Audioの内部構造をレイヤーごとに分割した。Scene Load、Service Locate、Save Data、Pauseと同じ形へ揃えている。**公開APIのシグネチャ、例外の種類と条件はいずれも変更していない。**

--- a/Documentation~/AgentUsage.md
+++ b/Documentation~/AgentUsage.md
@@ -8,7 +8,7 @@
 
 - `Packages/manifest.json`またはパッケージの`package.json`で導入バージョンを確認し、移行情報が必要なら[CHANGELOG.md](../CHANGELOG.md)を読む。
 - asmdefを使う利用側コードは`SymphonyFrameWork`を参照する。自動生成enumを直接使う場合だけ`SymphonyFrameWork.Enum`も参照する。
-- `ServiceLocator`、`SceneLoader`、`SaveDataRegistry`、`AudioManager`、`PauseManager`はstatic Facadeである。`new`や`.Instance`は使わない。
+- `ServiceLocator`、`SceneLoader`、`SaveStore`、`AudioManager`、`PauseManager`はstatic Facadeである。`new`や`.Instance`は使わない。
 - `SymphonyOrchestrator`が最初のシーンより前に自動初期化する。Bootstrap用GameObjectや専用シーンを作らない。
 - `SceneManagerConfig`、`AudioManagerConfig`、`SaveSystemConfig`は`internal`である。型として参照せず、InspectorまたはProject Settingsから設定する。
 - `SymphonyFrameWork.Editor`はEditor専用である。Runtime asmdefやPlayerビルド対象コードから参照しない。
@@ -20,7 +20,7 @@
 | --- | --- | --- | --- |
 | Service Locator | `SymphonyFrameWork.System.ServiceLocate` | `ServiceLocator`, `ServiceInjector` | [Service Locator](../README.md#service-locator) |
 | Scene Loader | `SymphonyFrameWork.System.SceneLoad` | `SceneLoader` | [Scene Loader](../README.md#scene-loader) |
-| Save Data System | `SymphonyFrameWork.System.SaveSystem` | `SaveDataRegistry`, `SaveDataContent`, `SaveDataLoader` | [Save Data System](../README.md#save-data-system) |
+| Save Data System | `SymphonyFrameWork.System.SaveSystem` | `SaveStore`, `SaveDataContent`, `SaveDataLoader` | [Save Data System](../README.md#save-data-system) |
 | Audio Manager | `SymphonyFrameWork.System` | `AudioManager` | [Audio Manager](../README.md#audio-manager) |
 | Pause Manager | `SymphonyFrameWork.System` | `PauseManager` | [Pause Manager](../README.md#pause-manager) |
 
@@ -45,11 +45,12 @@
 ## Save Data System
 
 - 保存型は`SaveDataContent`を継承した、デフォルトコンストラクタを持つ具象classにする。
-- `SaveDataRegistry.Get<T>()`が返す型単位のキャッシュを編集する。別インスタンスとの二重管理を作らない。
+- **旧`SaveDataRegistry`は非推奨である。** `SaveStore`へ置換する。動作は同じで、3.0.0で削除する。
+- `SaveStore.Get<T>()`が返す型単位のキャッシュを編集する。別インスタンスとの二重管理を作らない。
 - 非同期I/Oを行う独自ローダーでは、先に`LoadAsync<T>()`をawaitしてから`Get<T>()`する。
 - 保存先の失敗は`SaveDataOperationException`の`Operation`、`DataType`、`LoaderType`、`InnerException`で診断する。キャンセルは`OperationCanceledException`のまま伝播する。
 - 独自`SaveDataLoader`はProject Settingsの選択肢へ自動登録される。設定ScriptableObjectを手動生成しない。
-- キャッシュ済みの一覧は`SaveDataRegistry.GetEntries()`で取得する。型名の昇順で並んだ取得時点のスナップショットとして扱う。
+- キャッシュ済みの一覧は`SaveStore.GetEntries()`で取得する。型名の昇順で並んだ取得時点のスナップショットとして扱う。
 - **`Data != null`を「読み込み済み」の判定に使わない。** キャッシュは初回アクセス時に既定値で作られるため、両者は別の状態である。読み込み済みかどうかは`SaveDataRegistryEntryInfo.IsLoaded`で判定する。
 
 ## Audio Manager

--- a/Documentation~/Architecture.md
+++ b/Documentation~/Architecture.md
@@ -121,7 +121,7 @@ classDiagram
         <<interface>>
         InitializeAsync()
     }
-    class SaveDataRegistry {
+    class SaveStore {
         <<static>>
         Get()
         LoadAsync()
@@ -162,8 +162,8 @@ classDiagram
     SceneLoader --> SceneLoadInfo : 追跡状態のスナップショット
     SceneLoader ..> ServiceInjector : ルートへ自動注入
     SceneLoader --> IInitializeAsync : 完了を待機
-    SaveDataRegistry --> SaveDataContent : 型単位でキャッシュ
-    SaveDataRegistry --> SaveDataLoader : 永続化を委譲
+    SaveStore --> SaveDataContent : 型単位でキャッシュ
+    SaveStore --> SaveDataLoader : 永続化を委譲
     PauseManager --> IPausable : 状態を通知
 ```
 
@@ -212,7 +212,7 @@ Save DataのRuntime内部も同じ形で、処理順、読み取り変換、表�
 
 ```mermaid
 flowchart LR
-    Facade["SaveDataRegistry"] -->|Command| Service["SaveDataService"]
+    Facade["SaveStore"] -->|Command| Service["SaveDataService"]
     Service --> Registry["SaveDataEntryRegistry"]
     Registry --> Entity["SaveDataEntryEntity"]
     Facade -->|Query| Query["SaveDataQuery"]

--- a/Editor/Administrator/UITK/CS/SaveDataRegistryWindow.cs
+++ b/Editor/Administrator/UITK/CS/SaveDataRegistryWindow.cs
@@ -98,7 +98,7 @@ namespace SymphonyFrameWork.Editor
             ConfigureCacheList();
             EnsureTypeListCurrent();
 
-            SaveDataRegistry.OnCurrentViewModelChanged += ViewModelChangedHandler;
+            SaveStore.OnCurrentViewModelChanged += ViewModelChangedHandler;
             BindViewModel();
 
             return default;
@@ -114,7 +114,7 @@ namespace SymphonyFrameWork.Editor
 
             _disposed = true;
 
-            SaveDataRegistry.OnCurrentViewModelChanged -= ViewModelChangedHandler;
+            SaveStore.OnCurrentViewModelChanged -= ViewModelChangedHandler;
             UnbindViewModel();
 
             if (_editorContainer != null)
@@ -150,7 +150,7 @@ namespace SymphonyFrameWork.Editor
         {
             UnbindViewModel();
 
-            SaveDataViewModel viewModel = _disposed ? null : SaveDataRegistry.CurrentViewModel;
+            SaveDataViewModel viewModel = _disposed ? null : SaveStore.CurrentViewModel;
             if (viewModel == null)
             {
                 ApplyEntries(Array.Empty<SaveDataDto>());
@@ -350,7 +350,7 @@ namespace SymphonyFrameWork.Editor
                 SerializedProperty dataProperty = _debugSerializedObject.FindProperty("_data");
                 if (dataProperty.managedReferenceValue == null)
                 {
-                    // SaveDataRegistry.Get() は必ず何らかのインスタンスを返すため、型が選択されていれば
+                    // SaveStore.Get() は必ず何らかのインスタンスを返すため、型が選択されていれば
                     // ここには到達しない。到達するのは (a) プロジェクトに SaveDataContent を継承した型が
                     // 一つも無い、または (b) まだ何もインスタンス化されておらず自動選択もしていない場合のみ。
                     // どちらの理由かは _statusMessage 側で出し分けているので、そのままここに表示する。
@@ -379,7 +379,7 @@ namespace SymphonyFrameWork.Editor
                 return;
             }
 
-            SaveDataContent data = SaveDataRegistry.Get(_selectedType);
+            SaveDataContent data = SaveStore.Get(_selectedType);
             RebindDebugState(data);
             _statusMessage = $"{_selectedType.FullName} の現在インスタンスを表示しています。";
         }
@@ -387,8 +387,8 @@ namespace SymphonyFrameWork.Editor
         /// <summary> 選択中の型を保存先から再ロードして編集状態へ反映する。 </summary>
         private void LoadSelected()
         {
-            SaveDataRegistry.LoadAsync(_selectedType).GetAwaiter().GetResult();
-            SaveDataContent saveData = SaveDataRegistry.Get(_selectedType);
+            SaveStore.LoadAsync(_selectedType).GetAwaiter().GetResult();
+            SaveDataContent saveData = SaveStore.Get(_selectedType);
 
             RebindDebugState(saveData);
             _statusMessage = $"{_selectedType.FullName} をロードしました。";
@@ -408,14 +408,14 @@ namespace SymphonyFrameWork.Editor
             // インスペクタで編集中のインスタンスが [SerializeReference] の再構築などで
             // Registry のキャッシュ本体と別インスタンスになっている可能性があるため、
             // 保存前に編集内容を Registry 側の正本へ同期する（食い違ったまま Save してしまう事故を防ぐ）。
-            SaveDataContent canonical = SaveDataRegistry.Get(_selectedType);
+            SaveDataContent canonical = SaveStore.Get(_selectedType);
             if (!ReferenceEquals(canonical, editingData))
             {
                 JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(editingData), canonical);
             }
 
-            SaveDataRegistry.SaveAsync(_selectedType).GetAwaiter().GetResult();
-            SaveDataContent saveData = SaveDataRegistry.Get(_selectedType);
+            SaveStore.SaveAsync(_selectedType).GetAwaiter().GetResult();
+            SaveDataContent saveData = SaveStore.Get(_selectedType);
             RebindDebugState(saveData);
             _statusMessage = $"{_selectedType.FullName} を保存しました。";
             RefreshView();
@@ -433,8 +433,8 @@ namespace SymphonyFrameWork.Editor
                 return;
             }
 
-            SaveDataRegistry.DeleteAsync(_selectedType).GetAwaiter().GetResult();
-            SaveDataContent regenerated = SaveDataRegistry.Get(_selectedType);
+            SaveStore.DeleteAsync(_selectedType).GetAwaiter().GetResult();
+            SaveDataContent regenerated = SaveStore.Get(_selectedType);
             RebindDebugState(regenerated);
             _statusMessage = $"{_selectedType.FullName} の保存データを削除し、現在インスタンスを初期化しました。";
             RefreshView();
@@ -504,8 +504,8 @@ namespace SymphonyFrameWork.Editor
         /// <returns> ローダーの型名。未初期化の場合は代替表示。 </returns>
         private static string GetCurrentLoaderName()
         {
-            return SaveDataRegistry.IsInitialized
-                ? SaveDataRegistry.GetCurrentLoader().GetType().Name
+            return SaveStore.IsInitialized
+                ? SaveStore.GetCurrentLoader().GetType().Name
                 : "(uninitialized)";
         }
 
@@ -545,8 +545,8 @@ namespace SymphonyFrameWork.Editor
             List<SaveDataEntryRow> rows = new(_saveDataTypes.Count);
             foreach (Type saveDataType in _saveDataTypes)
             {
-                bool isSaved = SaveDataRegistry.IsInitialized
-                    && SaveDataRegistry.Exists(saveDataType);
+                bool isSaved = SaveStore.IsInitialized
+                    && SaveStore.Exists(saveDataType);
 
                 if (cachedEntries.TryGetValue(saveDataType, out SaveDataDto cachedEntry))
                 {

--- a/Editor/Debug/SymphonyMcpTools.cs
+++ b/Editor/Debug/SymphonyMcpTools.cs
@@ -123,7 +123,7 @@ namespace SymphonyFrameWork.Editor.Debugger
 
             try
             {
-                initialized = EditorApplication.isPlaying && SaveDataRegistry.IsInitialized;
+                initialized = EditorApplication.isPlaying && SaveStore.IsInitialized;
                 if (!initialized)
                 {
                     return Serialize(new
@@ -133,7 +133,7 @@ namespace SymphonyFrameWork.Editor.Debugger
                     });
                 }
 
-                var entries = SaveDataRegistry.GetEntries()
+                var entries = SaveStore.GetEntries()
                     .Select(entry => new
                     {
                         typeName = GetTypeName(entry.DataType),

--- a/Editor/PackageInitializer.cs
+++ b/Editor/PackageInitializer.cs
@@ -26,7 +26,7 @@ namespace SymphonyFrameWork.Editor
             ApplyServiceLocateLogOptions();
             SymphonyVisualElement.EditorAssetLoader =
                 AssetDatabase.LoadAssetAtPath<VisualTreeAsset>;
-            SaveDataRegistry.ConfigureLoaderResolver(ResolveSaveDataLoader);
+            SaveStore.ConfigureLoaderResolver(ResolveSaveDataLoader);
             hasAssetChanges |= EnumInitialize();
 
             return hasAssetChanges;

--- a/Editor/SettingProvider/SaveSystemSettingProvider.cs
+++ b/Editor/SettingProvider/SaveSystemSettingProvider.cs
@@ -39,7 +39,7 @@ namespace SymphonyFrameWork.Editor.SettingProvider
 
             EditorGUILayout.LabelField("Project Save Loader", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox(
-                "SaveDataRegistry が使用するローダーを設定します。独自ローダーは SaveDataLoader を継承してください。共通の検証やデータ復旧処理は基底クラスが担当します。",
+                "SaveStore が使用するローダーを設定します。独自ローダーは SaveDataLoader を継承してください。共通の検証やデータ復旧処理は基底クラスが担当します。",
                 MessageType.Info);
 
             SerializedObject serializedObject = new(config);
@@ -53,7 +53,7 @@ namespace SymphonyFrameWork.Editor.SettingProvider
                 serializedObject.ApplyModifiedProperties();
                 EditorUtility.SetDirty(config);
                 AssetDatabase.SaveAssets();
-                SaveDataRegistry.RefreshLoader();
+                SaveStore.RefreshLoader();
             }
             else
             {
@@ -62,7 +62,7 @@ namespace SymphonyFrameWork.Editor.SettingProvider
 
             if (config.Loader == null)
             {
-                EditorGUILayout.HelpBox("ローダーが未設定です。SaveDataRegistry は既定の JsonUtility ローダーへフォールバックします。", MessageType.Warning);
+                EditorGUILayout.HelpBox("ローダーが未設定です。SaveStore は既定の JsonUtility ローダーへフォールバックします。", MessageType.Warning);
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **2.18.1**
+- 現在のバージョン: **2.19.0**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること
@@ -220,12 +220,12 @@ public sealed class PlayerData : SaveDataContent
 Registryが保持するインスタンスを編集し、型を指定して保存します。
 
 ```csharp
-PlayerData data = SaveDataRegistry.Get<PlayerData>();
+PlayerData data = SaveStore.Get<PlayerData>();
 data.Gold += 100;
 
-await SaveDataRegistry.SaveAsync<PlayerData>();
-await SaveDataRegistry.LoadAsync<PlayerData>();
-await SaveDataRegistry.DeleteAsync<PlayerData>();
+await SaveStore.SaveAsync<PlayerData>();
+await SaveStore.LoadAsync<PlayerData>();
+await SaveStore.DeleteAsync<PlayerData>();
 ```
 
 既定ではJSONをPlayerPrefsへ保存します。別のシリアライザ、ファイル、クラウド等を使う場合は`SaveDataLoader`を継承し、Project Settingsから選択します。

--- a/Runtime/Orchestrator/Internal/SymphonyOrchestrator.cs
+++ b/Runtime/Orchestrator/Internal/SymphonyOrchestrator.cs
@@ -44,7 +44,7 @@ namespace SymphonyFrameWork.Orchestrator
                 UnityEngine.Object.DontDestroyOnLoad(systemGameObject);
 
                 SaveSystem.Initialize(ResolveSaveDataLoader);
-                RecordInitializedSubsystem(SaveDataRegistry.ResetRuntimeState);
+                RecordInitializedSubsystem(SaveStore.ResetRuntimeState);
 
                 PauseManager.Initialize();
                 RecordInitializedSubsystem(PauseManager.ResetRuntimeState);

--- a/Runtime/System/SaveSystem/Internal/Application/SaveDataService.cs
+++ b/Runtime/System/SaveSystem/Internal/Application/SaveDataService.cs
@@ -257,7 +257,7 @@ namespace SymphonyFrameWork.System.SaveSystem
             if (_cachedLoader == null)
             {
                 throw new InvalidOperationException(
-                    $"[{nameof(SaveDataRegistry)}] ローダーの解決結果がnullです。");
+                    $"[{nameof(SaveStore)}] ローダーの解決結果がnullです。");
             }
 
             return _cachedLoader;

--- a/Runtime/System/SaveSystem/Internal/SaveSystem.cs
+++ b/Runtime/System/SaveSystem/Internal/SaveSystem.cs
@@ -11,7 +11,7 @@ namespace SymphonyFrameWork.System.SaveSystem
         /// <param name="loaderResolver"> 現在のConfigに対応するローダーを返す処理。 </param>
         internal static void Initialize(Func<SaveDataLoader> loaderResolver)
         {
-            SaveDataRegistry.ConfigureLoaderResolver(loaderResolver);
+            SaveStore.ConfigureLoaderResolver(loaderResolver);
         }
     }
 }

--- a/Runtime/System/SaveSystem/SaveDataLoader.cs
+++ b/Runtime/System/SaveSystem/SaveDataLoader.cs
@@ -8,7 +8,7 @@ namespace SymphonyFrameWork.System.SaveSystem
     /// <summary>
     ///     セーブデータのライフサイクルを保証し、派生クラスをJSONの変換と永続化処理に限定します。
     ///     利用側は本クラスを継承して保存先を差し替えますが、呼び出しは
-    ///     <see cref="SaveDataRegistry" />が行うため、ここで宣言する操作は`internal`です。
+    ///     <see cref="SaveStore" />が行うため、ここで宣言する操作は`internal`です。
     /// </summary>
     [Serializable]
     public abstract class SaveDataLoader

--- a/Runtime/System/SaveSystem/SaveDataOperationException.cs
+++ b/Runtime/System/SaveSystem/SaveDataOperationException.cs
@@ -16,7 +16,7 @@ namespace SymphonyFrameWork.System.SaveSystem
             Type loaderType,
             Exception innerException)
             : base(
-                $"[{nameof(SaveDataRegistry)}] {dataType?.FullName ?? "(null)"} の{GetOperationName(operation)}に失敗しました。"
+                $"[{nameof(SaveStore)}] {dataType?.FullName ?? "(null)"} の{GetOperationName(operation)}に失敗しました。"
                 + $" Loader: {loaderType?.FullName ?? "(null)"}",
                 innerException)
         {

--- a/Runtime/System/SaveSystem/SaveDataRegistry.cs
+++ b/Runtime/System/SaveSystem/SaveDataRegistry.cs
@@ -3,202 +3,75 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SymphonyFrameWork.Exceptions;
-
 namespace SymphonyFrameWork.System.SaveSystem
 {
     /// <summary>
-    ///     プロジェクト設定に従ってセーブデータを一括管理するレジストリです。
-    ///     引数の検証と<see cref="SaveDataService"/>への転送だけを行い、状態は保持しません。
+    ///     <see cref="SaveStore"/>へ転送する非推奨のFacadeです。
+    ///     Round I1／I2で内部を分割した結果、この型はレジストリではなくストアになりました。
+    ///     引数の検証も状態の保持も行わず、すべて<see cref="SaveStore"/>へ委譲します。
     /// </summary>
+    [Obsolete("SaveStoreを使用してください。3.0.0で削除します。", error: false)]
     public static class SaveDataRegistry
     {
         /// <summary> 指定型の永続化データが存在するか確認する。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で存在確認に失敗した場合。 </exception>
-        public static bool Exists<T>() where T : SaveDataContent, new()
-        {
-            return Exists(typeof(T));
-        }
+        public static bool Exists<T>() where T : SaveDataContent, new() => SaveStore.Exists<T>();
 
         /// <summary> 指定型の永続化データが存在するか確認する。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で存在確認に失敗した場合。 </exception>
-        public static bool Exists(Type dataType)
-        {
-            ValidateDataType(dataType);
-            return EnsureInitialized().Exists(dataType);
-        }
+        public static bool Exists(Type dataType) => SaveStore.Exists(dataType);
 
         /// <summary> 指定型のキャッシュまたは保存済みデータを同期的に取得する。 </summary>
         /// <exception cref="SaveDataOperationException"> 初回の同期読み込みに失敗した場合。 </exception>
-        public static T Get<T>() where T : SaveDataContent, new()
-        {
-            return (T)Get(typeof(T));
-        }
+        public static T Get<T>() where T : SaveDataContent, new() => SaveStore.Get<T>();
 
         /// <summary>
-        ///     Registry が保持している現在のインスタンスを取得します。
+        ///     ストアが保持している現在のインスタンスを取得します。
         ///     キャッシュが無い初回アクセス時は、自動的に永続化データをロードします。
         /// </summary>
         /// <exception cref="SaveDataOperationException"> 初回の同期読み込みに失敗した場合。 </exception>
-        public static SaveDataContent Get(Type dataType)
-        {
-            ValidateDataType(dataType);
-            return EnsureInitialized().Get(dataType);
-        }
+        public static SaveDataContent Get(Type dataType) => SaveStore.Get(dataType);
 
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static async ValueTask<T> LoadAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
-        {
-            await LoadAsync(typeof(T), token);
-            return Get<T>();
-        }
+        public static ValueTask<T> LoadAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new() => SaveStore.LoadAsync<T>(token);
 
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask LoadAsync(Type dataType, CancellationToken token = default)
-        {
-            ValidateDataType(dataType);
-            return EnsureInitialized().LoadAsync(dataType, token);
-        }
+        public static ValueTask LoadAsync(Type dataType, CancellationToken token = default) =>
+            SaveStore.LoadAsync(dataType, token);
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
-        {
-            return SaveAsync(typeof(T), token);
-        }
+        public static ValueTask SaveAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new() => SaveStore.SaveAsync<T>(token);
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync(Type dataType, CancellationToken token = default)
-        {
-            ValidateDataType(dataType);
-            return EnsureInitialized().SaveAsync(dataType, token);
-        }
+        public static ValueTask SaveAsync(Type dataType, CancellationToken token = default) =>
+            SaveStore.SaveAsync(dataType, token);
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static async ValueTask DeleteAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
-        {
-            await DeleteAsync(typeof(T), token);
-        }
+        public static ValueTask DeleteAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new() => SaveStore.DeleteAsync<T>(token);
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask DeleteAsync(Type dataType, CancellationToken token = default)
-        {
-            ValidateDataType(dataType);
-            return EnsureInitialized().DeleteAsync(dataType, token);
-        }
+        public static ValueTask DeleteAsync(Type dataType, CancellationToken token = default) =>
+            SaveStore.DeleteAsync(dataType, token);
 
         /// <summary>
         ///     現在キャッシュされている全エントリの読み取り専用スナップショットを取得する。
         ///     並び順は<see cref="Type.FullName" />のordinal昇順。
         /// </summary>
-        public static IReadOnlyList<SaveDataRegistryEntryInfo> GetEntries()
-        {
-            return _query?.GetInfos() ?? Array.Empty<SaveDataRegistryEntryInfo>();
-        }
-
-        /// <summary> Save Data Registryが初期化済みかどうか。 </summary>
-        internal static bool IsInitialized => _service != null;
-
-        /// <summary>
-        ///     状態表示に接続するためのViewModel。未初期化の場合はnull。
-        ///     <see cref="OnCurrentViewModelChanged" />で差し替えを検知して接続し直す。
-        /// </summary>
-        internal static SaveDataViewModel CurrentViewModel => _viewModel;
-
-        /// <summary>
-        ///     <see cref="CurrentViewModel" />が差し替わったときに発行される。
-        ///     Save DataはEdit Modeでも初期化されるため、Play Mode遷移だけでは接続し直せない。
-        /// </summary>
-        internal static event Action OnCurrentViewModelChanged;
-
-        /// <summary>
-        ///     ローダーとキャッシュを破棄し、次回アクセス時にConfigから再解決する。
-        ///     Configを編集するEditorのProject Settings画面から呼び出す。
-        /// </summary>
-        internal static void RefreshLoader()
-        {
-            ResetRuntimeState();
-        }
-
-        /// <summary>
-        ///     Compositionが解決したローダーの取得処理を設定する。
-        /// </summary>
-        /// <param name="loaderResolver"> 現在のConfigに対応するローダーを返す処理。 </param>
-        internal static void ConfigureLoaderResolver(
-            Func<SaveDataLoader> loaderResolver)
-        {
-            if (loaderResolver == null)
-            {
-                throw new ArgumentNullException(nameof(loaderResolver));
-            }
-
-            _viewModel?.Dispose();
-            _service?.Reset();
-
-            var registry = new SaveDataEntryRegistry();
-            _service = new SaveDataService(registry, loaderResolver);
-            _query = new SaveDataQuery(registry);
-            _viewModel = new SaveDataViewModel(_query, _service);
-
-            OnCurrentViewModelChanged?.Invoke();
-        }
-
-        /// <summary> Domain Reloadの有無に依存しないようランタイム状態を初期化する。 </summary>
-        internal static void ResetRuntimeState()
-        {
-            _service?.Reset();
-        }
-
-        /// <summary>
-        ///     現在選択されているローダーを取得する。
-        ///     Adaptorが選んだ実装は公開APIへ出さず、状態を表示するEditorウィンドウからのみ参照する。
-        /// </summary>
-        internal static SaveDataLoader GetCurrentLoader() => EnsureInitialized().GetCurrentLoader();
-
-        /// <summary> Compositionからローダーが注入済みであることを確認する。 </summary>
-        /// <returns> 処理を委譲するService。 </returns>
-        private static SaveDataService EnsureInitialized()
-        {
-            return _service ?? throw new SymphonyNotInitializedException(typeof(SaveDataRegistry));
-        }
-
-        /// <summary> レジストリで扱えるデフォルトコンストラクタ付き具象型か検証する。 </summary>
-        private static void ValidateDataType(Type dataType)
-        {
-            if (dataType == null)
-            {
-                throw new ArgumentNullException(nameof(dataType));
-            }
-
-            if (!dataType.IsClass || dataType.IsAbstract || dataType.IsGenericTypeDefinition)
-            {
-                throw new ArgumentException("セーブ対象は new() 可能な具象クラスにしてください。", nameof(dataType));
-            }
-
-            if (dataType.GetConstructor(Type.EmptyTypes) == null)
-            {
-                throw new ArgumentException("デフォルトコンストラクタが必要です。", nameof(dataType));
-            }
-
-            if (!typeof(SaveDataContent).IsAssignableFrom(dataType))
-            {
-                throw new ArgumentException($"{nameof(SaveDataContent)} を継承した型を指定してください。", nameof(dataType));
-            }
-        }
-
-        private static SaveDataService _service;
-        private static SaveDataQuery _query;
-        private static SaveDataViewModel _viewModel;
+        public static IReadOnlyList<SaveDataRegistryEntryInfo> GetEntries() => SaveStore.GetEntries();
     }
 }

--- a/Runtime/System/SaveSystem/SaveDataRegistry.cs.meta
+++ b/Runtime/System/SaveSystem/SaveDataRegistry.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 0c1ed01977f6efc4e8dddc42bc9aa436
+guid: c72c82f58e83c4445b16cae1a0c9e9f4

--- a/Runtime/System/SaveSystem/SaveDataRegistryEntryInfo.cs
+++ b/Runtime/System/SaveSystem/SaveDataRegistryEntryInfo.cs
@@ -7,7 +7,7 @@ namespace SymphonyFrameWork.System.SaveSystem
     {
         /// <summary>
         ///     セーブデータ型とキャッシュインスタンスから情報を生成する。
-        ///     生成は<see cref="SaveDataQuery" />の責務であり、利用側は<see cref="SaveDataRegistry.GetEntries" />で取得する。
+        ///     生成は<see cref="SaveDataQuery" />の責務であり、利用側は<see cref="SaveStore.GetEntries" />で取得する。
         /// </summary>
         internal SaveDataRegistryEntryInfo(Type dataType, SaveDataContent data, bool isLoaded)
         {

--- a/Runtime/System/SaveSystem/SaveStore.cs
+++ b/Runtime/System/SaveSystem/SaveStore.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using SymphonyFrameWork.Exceptions;
+
+namespace SymphonyFrameWork.System.SaveSystem
+{
+    /// <summary>
+    ///     プロジェクト設定に従ってセーブデータを一括管理するストアです。
+    ///     引数の検証と<see cref="SaveDataService"/>への転送だけを行い、状態は保持しません。
+    /// </summary>
+    public static class SaveStore
+    {
+        /// <summary> 指定型の永続化データが存在するか確認する。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で存在確認に失敗した場合。 </exception>
+        public static bool Exists<T>() where T : SaveDataContent, new()
+        {
+            return Exists(typeof(T));
+        }
+
+        /// <summary> 指定型の永続化データが存在するか確認する。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で存在確認に失敗した場合。 </exception>
+        public static bool Exists(Type dataType)
+        {
+            ValidateDataType(dataType);
+            return EnsureInitialized().Exists(dataType);
+        }
+
+        /// <summary> 指定型のキャッシュまたは保存済みデータを同期的に取得する。 </summary>
+        /// <exception cref="SaveDataOperationException"> 初回の同期読み込みに失敗した場合。 </exception>
+        public static T Get<T>() where T : SaveDataContent, new()
+        {
+            return (T)Get(typeof(T));
+        }
+
+        /// <summary>
+        ///     ストアが保持している現在のインスタンスを取得します。
+        ///     キャッシュが無い初回アクセス時は、自動的に永続化データをロードします。
+        /// </summary>
+        /// <exception cref="SaveDataOperationException"> 初回の同期読み込みに失敗した場合。 </exception>
+        public static SaveDataContent Get(Type dataType)
+        {
+            ValidateDataType(dataType);
+            return EnsureInitialized().Get(dataType);
+        }
+
+        /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static async ValueTask<T> LoadAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
+        {
+            await LoadAsync(typeof(T), token);
+            return Get<T>();
+        }
+
+        /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static ValueTask LoadAsync(Type dataType, CancellationToken token = default)
+        {
+            ValidateDataType(dataType);
+            return EnsureInitialized().LoadAsync(dataType, token);
+        }
+
+        /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static ValueTask SaveAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
+        {
+            return SaveAsync(typeof(T), token);
+        }
+
+        /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static ValueTask SaveAsync(Type dataType, CancellationToken token = default)
+        {
+            ValidateDataType(dataType);
+            return EnsureInitialized().SaveAsync(dataType, token);
+        }
+
+        /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static async ValueTask DeleteAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
+        {
+            await DeleteAsync(typeof(T), token);
+        }
+
+        /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
+        /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
+        /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
+        public static ValueTask DeleteAsync(Type dataType, CancellationToken token = default)
+        {
+            ValidateDataType(dataType);
+            return EnsureInitialized().DeleteAsync(dataType, token);
+        }
+
+        /// <summary>
+        ///     現在キャッシュされている全エントリの読み取り専用スナップショットを取得する。
+        ///     並び順は<see cref="Type.FullName" />のordinal昇順。
+        /// </summary>
+        public static IReadOnlyList<SaveDataRegistryEntryInfo> GetEntries()
+        {
+            return _query?.GetInfos() ?? Array.Empty<SaveDataRegistryEntryInfo>();
+        }
+
+        /// <summary> Save Storeが初期化済みかどうか。 </summary>
+        internal static bool IsInitialized => _service != null;
+
+        /// <summary>
+        ///     状態表示に接続するためのViewModel。未初期化の場合はnull。
+        ///     <see cref="OnCurrentViewModelChanged" />で差し替えを検知して接続し直す。
+        /// </summary>
+        internal static SaveDataViewModel CurrentViewModel => _viewModel;
+
+        /// <summary>
+        ///     <see cref="CurrentViewModel" />が差し替わったときに発行される。
+        ///     Save DataはEdit Modeでも初期化されるため、Play Mode遷移だけでは接続し直せない。
+        /// </summary>
+        internal static event Action OnCurrentViewModelChanged;
+
+        /// <summary>
+        ///     ローダーとキャッシュを破棄し、次回アクセス時にConfigから再解決する。
+        ///     Configを編集するEditorのProject Settings画面から呼び出す。
+        /// </summary>
+        internal static void RefreshLoader()
+        {
+            ResetRuntimeState();
+        }
+
+        /// <summary>
+        ///     Compositionが解決したローダーの取得処理を設定する。
+        /// </summary>
+        /// <param name="loaderResolver"> 現在のConfigに対応するローダーを返す処理。 </param>
+        internal static void ConfigureLoaderResolver(
+            Func<SaveDataLoader> loaderResolver)
+        {
+            if (loaderResolver == null)
+            {
+                throw new ArgumentNullException(nameof(loaderResolver));
+            }
+
+            _viewModel?.Dispose();
+            _service?.Reset();
+
+            var registry = new SaveDataEntryRegistry();
+            _service = new SaveDataService(registry, loaderResolver);
+            _query = new SaveDataQuery(registry);
+            _viewModel = new SaveDataViewModel(_query, _service);
+
+            OnCurrentViewModelChanged?.Invoke();
+        }
+
+        /// <summary> Domain Reloadの有無に依存しないようランタイム状態を初期化する。 </summary>
+        internal static void ResetRuntimeState()
+        {
+            _service?.Reset();
+        }
+
+        /// <summary>
+        ///     現在選択されているローダーを取得する。
+        ///     Adaptorが選んだ実装は公開APIへ出さず、状態を表示するEditorウィンドウからのみ参照する。
+        /// </summary>
+        internal static SaveDataLoader GetCurrentLoader() => EnsureInitialized().GetCurrentLoader();
+
+        /// <summary> Compositionからローダーが注入済みであることを確認する。 </summary>
+        /// <returns> 処理を委譲するService。 </returns>
+        private static SaveDataService EnsureInitialized()
+        {
+            return _service ?? throw new SymphonyNotInitializedException(typeof(SaveStore));
+        }
+
+        /// <summary> ストアで扱えるデフォルトコンストラクタ付き具象型か検証する。 </summary>
+        private static void ValidateDataType(Type dataType)
+        {
+            if (dataType == null)
+            {
+                throw new ArgumentNullException(nameof(dataType));
+            }
+
+            if (!dataType.IsClass || dataType.IsAbstract || dataType.IsGenericTypeDefinition)
+            {
+                throw new ArgumentException("セーブ対象は new() 可能な具象クラスにしてください。", nameof(dataType));
+            }
+
+            if (dataType.GetConstructor(Type.EmptyTypes) == null)
+            {
+                throw new ArgumentException("デフォルトコンストラクタが必要です。", nameof(dataType));
+            }
+
+            if (!typeof(SaveDataContent).IsAssignableFrom(dataType))
+            {
+                throw new ArgumentException($"{nameof(SaveDataContent)} を継承した型を指定してください。", nameof(dataType));
+            }
+        }
+
+        private static SaveDataService _service;
+        private static SaveDataQuery _query;
+        private static SaveDataViewModel _viewModel;
+    }
+}

--- a/Runtime/System/SaveSystem/SaveStore.cs.meta
+++ b/Runtime/System/SaveSystem/SaveStore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c1ed01977f6efc4e8dddc42bc9aa436

--- a/Samples/Runtime/SaveDataSystemSample/Scripts/SaveDataSystemSample_Controller.cs
+++ b/Samples/Runtime/SaveDataSystemSample/Scripts/SaveDataSystemSample_Controller.cs
@@ -20,8 +20,8 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         private void Start()
         {
             AddCommentary("サンプルを開始しました。永続化済みデータを Registry にロードします。");
-            _PlayerDataA = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
-            _PlayerDataB = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataB>();
+            _PlayerDataA = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
+            _PlayerDataB = SaveStore.Get<SaveDataSystemSample_PlayerDataB>();
             ReportLoadedDataA();
             ReportLoadedDataB();
         }
@@ -39,7 +39,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
             AddCommentary("Registry が保持している現在インスタンスを永続化します。");
 
             SaveDataSystemSample_PlayerDataA data = _PlayerDataA;
-            await SaveDataRegistry.SaveAsync<SaveDataSystemSample_PlayerDataA>();
+            await SaveStore.SaveAsync<SaveDataSystemSample_PlayerDataA>();
             AddCommentary($"保存完了: {data.PlayerName} / Level {data.Level} / Gold {data.Gold}");
             Debug.Log($"Saved: {data.PlayerName} Lv.{data.Level} Gold:{data.Gold}");
             _isBusy = false;
@@ -71,7 +71,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
 
             _isBusy = true;
             AddCommentary("永続化データと Registry 上の現在インスタンスを削除します。次回アクセス時は初期データが自動生成されます。");
-            await SaveDataRegistry.DeleteAsync<SaveDataSystemSample_PlayerDataA>();
+            await SaveStore.DeleteAsync<SaveDataSystemSample_PlayerDataA>();
             AddCommentary("削除完了。次のアクセスで Registry が新しい初期インスタンスを生成します。");
             Debug.Log("Deleted SaveDataSystemSample_PlayerData");
             _isBusy = false;
@@ -80,8 +80,8 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataAを再読込し、画面が参照するインスタンスとログを更新する。 </summary>
         private async Awaitable LoadInternalAsync()
         {
-            await SaveDataRegistry.LoadAsync<SaveDataSystemSample_PlayerDataA>();
-            _PlayerDataA = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
+            await SaveStore.LoadAsync<SaveDataSystemSample_PlayerDataA>();
+            _PlayerDataA = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
             ReportLoadedDataA();
         }
 
@@ -106,7 +106,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
             AddCommentary("Registry が保持している DataB の現在インスタンスを永続化します。");
 
             SaveDataSystemSample_PlayerDataB data = _PlayerDataB;
-            await SaveDataRegistry.SaveAsync<SaveDataSystemSample_PlayerDataB>();
+            await SaveStore.SaveAsync<SaveDataSystemSample_PlayerDataB>();
             AddCommentary($"保存完了(B): ItemIDs [{FormatItemIDs(data)}]");
             Debug.Log($"Saved(B): [{FormatItemIDs(data)}]");
             _isBusy = false;
@@ -138,7 +138,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
 
             _isBusy = true;
             AddCommentary("DataB の永続化データと Registry 上の現在インスタンスを削除します。");
-            await SaveDataRegistry.DeleteAsync<SaveDataSystemSample_PlayerDataB>();
+            await SaveStore.DeleteAsync<SaveDataSystemSample_PlayerDataB>();
             AddCommentary("削除完了(B)。次のアクセスで Registry が新しい初期インスタンスを生成します。");
             Debug.Log("Deleted SaveDataSystemSample_PlayerDataB");
             _isBusy = false;
@@ -147,8 +147,8 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataBを再読込し、画面が参照するインスタンスとログを更新する。 </summary>
         private async Awaitable LoadInternalAsyncB()
         {
-            await SaveDataRegistry.LoadAsync<SaveDataSystemSample_PlayerDataB>();
-            _PlayerDataB = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataB>();
+            await SaveStore.LoadAsync<SaveDataSystemSample_PlayerDataB>();
+            _PlayerDataB = SaveStore.Get<SaveDataSystemSample_PlayerDataB>();
             ReportLoadedDataB();
         }
 
@@ -188,7 +188,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
             GUILayout.Label($"Editing Level: {dataA.Level}");
             GUILayout.Label($"Editing Gold : {dataA.Gold}");
             GUILayout.Label($"Save Date    : {dataA.SaveDate ?? "(unsaved)"}");
-            GUILayout.Label($"Saved Exists : {SaveDataRegistry.Exists<SaveDataSystemSample_PlayerDataA>()}");
+            GUILayout.Label($"Saved Exists : {SaveStore.Exists<SaveDataSystemSample_PlayerDataA>()}");
             GUILayout.Label($"Cache Loaded : {IsCacheLoaded<SaveDataSystemSample_PlayerDataA>()}");
             GUILayout.Label($"Busy         : {_isBusy}");
             GUILayout.Space(8f);
@@ -214,7 +214,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
             GUILayout.Label("---- DataB (Items) ----");
             GUILayout.Label($"Item IDs     : [{FormatItemIDs(dataB)}]");
             GUILayout.Label($"Save Date(B) : {dataB.SaveDate ?? "(unsaved)"}");
-            GUILayout.Label($"Saved Exists : {SaveDataRegistry.Exists<SaveDataSystemSample_PlayerDataB>()}");
+            GUILayout.Label($"Saved Exists : {SaveStore.Exists<SaveDataSystemSample_PlayerDataB>()}");
             GUILayout.Label($"Cache Loaded : {IsCacheLoaded<SaveDataSystemSample_PlayerDataB>()}");
             GUILayout.Space(8f);
 
@@ -241,7 +241,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataAのプレイヤー名を定義済み候補の次の値へ変更する。 </summary>
         private void RenameHero()
         {
-            SaveDataSystemSample_PlayerDataA data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
+            SaveDataSystemSample_PlayerDataA data = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
             string playerName = data.PlayerName;
             playerName = playerName == NAME_OPTION_1
                 ? NAME_OPTION_2
@@ -260,7 +260,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataAの編集中の値をサンプル既定値へ戻す。 </summary>
         private void ResetDraft()
         {
-            SaveDataSystemSample_PlayerDataA data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
+            SaveDataSystemSample_PlayerDataA data = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
             data.PlayerName = NAME_OPTION_1;
             data.Level = 1;
             data.Gold = 100;
@@ -270,7 +270,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataAのレベルを1増加させる。 </summary>
         private void IncreaseLevel()
         {
-            SaveDataSystemSample_PlayerDataA data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
+            SaveDataSystemSample_PlayerDataA data = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
             data.Level++;
             AddCommentary("Level を 1 増やしました。まだ保存はされていません。");
         }
@@ -278,7 +278,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataAの所持金を100増加させる。 </summary>
         private void IncreaseGold()
         {
-            SaveDataSystemSample_PlayerDataA data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataA>();
+            SaveDataSystemSample_PlayerDataA data = SaveStore.Get<SaveDataSystemSample_PlayerDataA>();
             data.Gold += 100;
             AddCommentary("Gold を 100 増やしました。まだ保存はされていません。");
         }
@@ -286,7 +286,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataBへ既存最大値の次のアイテムIDを追加する。 </summary>
         private void AddItem()
         {
-            SaveDataSystemSample_PlayerDataB data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataB>();
+            SaveDataSystemSample_PlayerDataB data = SaveStore.Get<SaveDataSystemSample_PlayerDataB>();
             int nextId = data.ItemIDs.Length == 0 ? 1 : data.ItemIDs.Max() + 1;
             data.ItemIDs = data.ItemIDs.Append(nextId).ToArray();
             AddCommentary($"Item {nextId} を追加しました。まだ保存はされていません。");
@@ -295,7 +295,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> DataBのアイテムID一覧を空にする。 </summary>
         private void ClearItems()
         {
-            SaveDataSystemSample_PlayerDataB data = SaveDataRegistry.Get<SaveDataSystemSample_PlayerDataB>();
+            SaveDataSystemSample_PlayerDataB data = SaveStore.Get<SaveDataSystemSample_PlayerDataB>();
             data.ItemIDs = Array.Empty<int>();
             AddCommentary("Item をすべて削除しました。まだ保存はされていません。");
         }
@@ -309,7 +309,7 @@ namespace SymphonyFrameWork.Samples.SaveDataSystemSample
         /// <summary> 指定型のデータがRegistryへキャッシュ済みか確認する。 </summary>
         private static bool IsCacheLoaded<T>() where T : SaveDataContent, new()
         {
-            foreach (SaveDataRegistryEntryInfo entry in SaveDataRegistry.GetEntries())
+            foreach (SaveDataRegistryEntryInfo entry in SaveStore.GetEntries())
             {
                 if (entry.DataType == typeof(T))
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Round L1。Phase 4 の最初のラウンドです。

設計書: `Documentation/Designs/SaveStoreRename.md`（ワークスペース側）

Round I1／I2 で内部を分割した結果、**この型はレジストリではなくストアになっていました。** 実際のレジストリは `SaveDataEntryRegistry`（内部）で、名前が役割と食い違っていたため改名します。

## 後方互換です

`SaveDataRegistry` は `[Obsolete]` の転送Facadeとして残ります。利用側は**コンパイルが通り、`CS0618` で移行先が案内されます**。移行は `SaveDataRegistry` → `SaveStore` の置換だけです。削除は 3.0.0。

実際にホスト側へ旧APIを呼ぶ一時ファイルを置いて確認しました。

```
warning CS0618: 'SaveDataRegistry' is obsolete: 'SaveStoreを使用してください。3.0.0で削除します。'
```

## Phase 4 の範囲を狭めました

着手前の調査で、ArchitectureRevision の Phase 4 が計画どおりには後方互換にならないことが分かりました。

| 対象 | シム | 扱い |
|---|---|---|
| `SaveDataRegistry` → `SaveStore` | 可 | **本 PR** |
| `SaveDataLoader` → `SaveDataLoaderStrategy` | 可 | Round L2 |
| `SceneManagerConfig` → `SceneLoadConfig` | 可（`[MovedFrom]`） | Round L2 |
| 公開 enum 6型の `Enum` サフィックス化 | **不可** | **3.0.0 へ** |

**enum にはシムが作れません。** 別の enum 型どうしに暗黙変換は無く、enum に演算子も定義できません。`SceneLoadState` → `SceneLoadStateEnum` にすると `SceneLoadInfo.State` の型が変わり、それを読む利用側コードが必ず壊れます。

対象は6型で、ArchitectureRevision の「7つ」より1つ少ない値です（`AssetProtectionModeEnum` は既にサフィックス済み）。

## 改名しなかったもの

`SaveDataRegistryEntryInfo` と Editor の `SaveDataRegistryWindow` は据え置きです。`GetEntries()` の戻り値要素型を変えると、struct に暗黙変換を定義しても `IReadOnlyList<A>` と `IReadOnlyList<B>` は変換できず**破壊的になる**ためです。3.0.0 でまとめて扱います。

## テストを追加していない理由

改名と転送だけで、検証すべき新しい振る舞いがありません。代わりに**コンパイル警告0が「フレームワーク内に旧APIへの参照が1件も残っていない」ことの機械的な証拠**になります。`[Obsolete]` は参照があれば必ず警告を出すためです。

## 検証

- `uloop compile` — エラー0・**SymphonyFrameWork 由来の警告0**
- EditMode **222/222 を2回連続**、PlayMode 4/4（`Success` / `Passed` / `Failed` / `Skipped` すべて確認）
- `rg "SaveDataRegistry\."` がシム定義以外0件
- 利用側の移行を模擬し、`CS0618` が出てコンパイルが通ることを確認
- `.meta` の GUID 重複なし
- この Round の `.cs` はすべて UTF-8 BOM 付き

Play Mode での Sample を使った手動確認は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)