### PR TITLE
[update]Pauseの非同期APIをAwaitableへ移行（3.0.0-preview.1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [3.0.0-preview.1] - 2026-08-04
+
+**3.0.0 系の最初のプレビューです。** 破壊的変更を段階的に積み上げ、Phase 5（Awaitable移行）とPhase 6（改名とシム削除）を終えた時点で `3.0.0` として確定します。プレビュー版は「壊れることを承知で先行して試す」ためのものです。
+
+### Breaking
+- **`PauseManager` の非同期APIが `Task` ではなく `Awaitable` を返すようになりました。** 対象は `PausableNextFrameAsync`、`PausableWaitForSecondAsync`、`PausableWaitUntil` の3つです。
+
+  **移行方法**: `await` して使っている場合、**ソースの変更は不要です。**
+
+  ```csharp
+  // 2.x でも 3.0.0 でもそのまま動く
+  await PauseManager.PausableWaitForSecondAsync(1.0f, destroyCancellationToken);
+  ```
+
+  変更が必要なのは、戻り値を `Task` として受けている場合だけです。
+
+  ```csharp
+  // 2.x
+  Task task = PauseManager.PausableWaitForSecondAsync(1.0f);
+  await Task.WhenAll(task, other);
+
+  // 3.0.0
+  await SymphonyAwaitable.WhenAll(
+      PauseManager.PausableWaitForSecondAsync(1.0f),
+      other);
+  ```
+
+  **`Awaitable` は1回しか `await` できず、保存や共有ができません。** フィールドへ持たず、その場で待機してください。`Task` と混ぜる必要がある場合は `SymphonyAwaitable.AsTask` で変換します。
+
+  引数、例外の種類と条件、キャンセルの扱いは変更していません。キャンセル時は従来どおり `OperationCanceledException` です。
+
+  `PausableWaitForSecond`（Coroutine用の `IEnumerator` 版）、`PausableDestroy`、`PausableInvoke` は変更していません。`async void` の2つは、戻り値を持たせると await されなかった例外が観測できなくなるため据え置きます。
+
+### Add
+- Pauseの非同期APIのPlayModeテストを5件追加した。フレーム進行、指定秒の経過、**ポーズ中に待機が進まないこと**、キャンセル時の例外型、条件待機を検証する。
+  - キャンセルの検証は `Awaitable` を直接 `await` して行う。`AsTask` で包むと `TaskCanceledException` に化け、利用側が実際に受け取る型を測れないため。
+
 ## [2.20.0] - 2026-08-04
 ### Add
 - セーブデータの保存先を差し替える拡張点を `SaveDataLoaderStrategy` と `PlayerPrefsSaveDataLoaderStrategy` へ改名した。DesignPhilosophy の「拡張点には役割を表すサフィックスを付ける」に従う。中身（`protected abstract` メンバー）は変更していない。

--- a/Documentation~/AgentUsage.md
+++ b/Documentation~/AgentUsage.md
@@ -61,6 +61,7 @@
 ## Pause Manager
 
 - ポーズ中も止める待機には`PausableWaitForSecondAsync`、`PausableWaitForSecond`、`PausableNextFrameAsync`を使う。`Task.Delay`や通常の`WaitForSeconds`では代用しない。
+- **非同期の待機APIは`Awaitable`を返す。** `Awaitable`は1回しか`await`できず、保存も共有もできない。フィールドへ持たず、その場で待機する。複数待機は`SymphonyAwaitable.WhenAll`、`Task`と混ぜる場合は`SymphonyAwaitable.AsTask`を使う。
 - `PauseManager.IPausable`は有効化時に登録し、無効化時に解除する。同じ対象を重複登録しても通知は1回だけ届く。
 - **`OnPauseChanged`は値が変わったときだけ発行される。** `Pause = true`を2回続けても`IPausable.Pause()`は1回しか呼ばれない。同じ値の再設定を通知の起点にしない。
 - ポーズ状態と`IPausable`の購読件数をまとめて調べる場合は`PauseManager.GetPauseInfo()`を使い、戻る`PauseInfo`を取得時点のスナップショットとして扱う。購読件数は解除し忘れの検出に使える。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **2.20.0**
+- 現在のバージョン: **3.0.0-preview.1**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること

--- a/Runtime/System/Pause/PauseManager.cs
+++ b/Runtime/System/Pause/PauseManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Threading;
-using System.Threading.Tasks;
 
 using SymphonyFrameWork.Exceptions;
 using SymphonyFrameWork.Utility;
@@ -81,7 +80,7 @@ namespace SymphonyFrameWork.System
         ///     ポーズ時に停止するNextFrameAsync
         /// </summary>
         /// <param name="token"> 待機を中断するためのトークン。 </param>
-        public static async Task PausableNextFrameAsync(CancellationToken token = default)
+        public static async Awaitable PausableNextFrameAsync(CancellationToken token = default)
         {
             PauseQuery query = EnsureQuery();
 
@@ -113,8 +112,8 @@ namespace SymphonyFrameWork.System
         /// </summary>
         /// <param name="time"> ポーズ時間を除いて待機する秒数。 </param>
         /// <param name="token"> 待機を中断するためのトークン。 </param>
-        /// <returns> 待機処理を表すTask。 </returns>
-        public static async Task PausableWaitForSecondAsync(float time, CancellationToken token = default)
+        /// <returns> 待機処理を表すAwaitable。 </returns>
+        public static async Awaitable PausableWaitForSecondAsync(float time, CancellationToken token = default)
         {
             PauseQuery query = EnsureQuery();
             ValidateDuration(time, nameof(time));
@@ -131,8 +130,8 @@ namespace SymphonyFrameWork.System
         /// </summary>
         /// <param name="action"> 待機終了条件を返す処理。 </param>
         /// <param name="token"> 待機を中断するためのトークン。 </param>
-        /// <returns> 条件成立までの待機処理を表すTask。 </returns>
-        public static async Task PausableWaitUntil(Func<bool> action, CancellationToken token = default)
+        /// <returns> 条件成立までの待機処理を表すAwaitable。 </returns>
+        public static async Awaitable PausableWaitUntil(Func<bool> action, CancellationToken token = default)
         {
             PauseQuery query = EnsureQuery();
 

--- a/Tests/Runtime/PauseAwaitableRuntimeTests.cs
+++ b/Tests/Runtime/PauseAwaitableRuntimeTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System;
+using SymphonyFrameWork.Utility;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary>
+    ///     PauseManagerの非同期APIがAwaitableへ移行してもタイミングとキャンセルの
+    ///     契約を保つことを検証する。フレーム進行を伴うためPlayModeで実行する。
+    ///     PauseManagerはSymphonyOrchestratorがPlay Mode開始時に初期化する。
+    /// </summary>
+    public sealed class PauseAwaitableRuntimeTests
+    {
+        /// <summary> 各テストの後でポーズ状態を戻し、次のテストへ持ち越さない。 </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (PauseManager.IsInitialized)
+            {
+                PauseManager.Pause = false;
+            }
+        }
+
+        /// <summary> PausableNextFrameAsyncを待機するとフレームが進む。 </summary>
+        [UnityTest]
+        public IEnumerator PausableNextFrameAsync_AdvancesFrame()
+        {
+            int startFrame = Time.frameCount;
+            Task task = SymphonyAwaitable.AsTask(PauseManager.PausableNextFrameAsync());
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            task.GetAwaiter().GetResult();
+            Assert.That(Time.frameCount, Is.GreaterThan(startFrame));
+        }
+
+        /// <summary> PausableWaitForSecondAsyncは指定秒の経過後に完了する。 </summary>
+        [UnityTest]
+        public IEnumerator PausableWaitForSecondAsync_CompletesAfterDuration()
+        {
+            float startedAt = Time.realtimeSinceStartup;
+            Task task = SymphonyAwaitable.AsTask(
+                PauseManager.PausableWaitForSecondAsync(0.1f));
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            task.GetAwaiter().GetResult();
+            Assert.That(
+                Time.realtimeSinceStartup - startedAt,
+                Is.GreaterThanOrEqualTo(0.05f));
+        }
+
+        /// <summary>
+        ///     **ポーズ中は待機が進まない。**
+        ///     Awaitableへの移行で最も壊れやすいのがこの時間の扱いであり、
+        ///     戻り値型ではなくタイミングの契約を検証する。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator PausableWaitForSecondAsync_DoesNotAdvanceWhilePaused()
+        {
+            PauseManager.Pause = true;
+
+            Task task = SymphonyAwaitable.AsTask(
+                PauseManager.PausableWaitForSecondAsync(0.1f));
+
+            for (int i = 0; i < 30; i++)
+            {
+                yield return null;
+            }
+
+            Assert.That(task.IsCompleted, Is.False, "ポーズ中に待機が完了してはいけない。");
+
+            PauseManager.Pause = false;
+
+            yield return new WaitUntil(() => task.IsCompleted);
+            task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///     キャンセル済みトークンではOperationCanceledExceptionになる。
+        ///     **Awaitableを直接awaitして観測する。** AsTaskで包むとTask側の
+        ///     TaskCanceledExceptionに化けてしまい、利用側が実際に受け取る型を測れない。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator PausableWaitForSecondAsync_Canceled_ThrowsOperationCanceled()
+        {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            Exception captured = null;
+
+            async Task AwaitDirectlyAsync()
+            {
+                try
+                {
+                    await PauseManager.PausableWaitForSecondAsync(0.1f, cancellation.Token);
+                }
+                catch (Exception exception)
+                {
+                    captured = exception;
+                }
+            }
+
+            Task task = AwaitDirectlyAsync();
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            Assert.That(captured, Is.InstanceOf<OperationCanceledException>());
+        }
+
+        /// <summary> PausableWaitUntilは条件成立で完了する。 </summary>
+        [UnityTest]
+        public IEnumerator PausableWaitUntil_CompletesWhenConditionMet()
+        {
+            bool condition = false;
+            Task task = SymphonyAwaitable.AsTask(
+                PauseManager.PausableWaitUntil(() => condition));
+
+            for (int i = 0; i < 3; i++)
+            {
+                yield return null;
+            }
+
+            Assert.That(task.IsCompleted, Is.False, "条件が成立するまで完了してはいけない。");
+
+            condition = true;
+
+            yield return new WaitUntil(() => task.IsCompleted);
+            task.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Tests/Runtime/PauseAwaitableRuntimeTests.cs.meta
+++ b/Tests/Runtime/PauseAwaitableRuntimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f996ee3d45f6d84c9c3c45765fcca02

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "2.20.0",
+  "version": "3.0.0-preview.1",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Round M1。Phase 5（Awaitable シグネチャ移行）の最初のラウンドです。

設計書: `Documentation/Designs/AwaitableMigration.md`（ワークスペース側）

## 3.0.0 系として進めます

**公開APIの戻り値型を変えるため、追加による後方互換化ができません。** C# は戻り値型だけが異なる多重定義を許さず、`SaveStore.LoadAsync<T>()` のようにすでに `Async` 接尾辞を使っている API では逃げ場がありません。

各 Round を個別にリリース可能に保つため、**`3.0.0-preview.N` を積み上げ、Phase 6 の最後で接尾辞を落とします。** 破壊的変更を `develop` へ溜め込むと途中の Round が単独でリリースできなくなるためです。

## 変更

`PausableNextFrameAsync` / `PausableWaitForSecondAsync` / `PausableWaitUntil` の戻り値を `Task` から `Awaitable` へ。**本体の処理は変えていません。**

`await` して使っている限り**利用側のソース変更は不要**です。変更が必要なのは戻り値を `Task` として受けている場合だけで、CHANGELOG に前後の例を載せています。

`async void` の `PausableDestroy` / `PausableInvoke` は据え置きました。`Awaitable` を返す形にすると呼び出し側が待機できるようになりますが、**await されなかった場合に例外が失われます**。現在は Unity の未処理例外ハンドラへ届いてログに出るため、観測性を下げる変更になります。

## Awaitable の制約と、内部で `Task` を残す方針

`Awaitable` は**1回しか await できず、保存も共有もできません**。現行コードには共有を前提とした箇所が2つあります。

| 箇所 | 用途 | 扱い |
|---|---|---|
| `SaveDataService._loadingTasks` | 進行中ロードの重複排除 | **`Task` のまま。** 公開APIは `SymphonyAwaitable.FromTask` で包む |
| `IInitializeAsync.InitializeTask` | 初期化の完了状態を保持 | Round M5 で判断 |

当初計画の「共有された非同期値を全文検索で除去する」は、この2箇所には適用しません。除去すると重複ロードの排除（Round I1 で回帰テストを書いた不変条件）が壊れます。

## テストで1件発見しました

キャンセル時の例外型のテストが2回とも落ちました。原因は**私のテストが `AsTask` で包んだ Task の例外を測っていた**ことで、`TaskCanceledException` に化けていました。`Awaitable` を直接 `await` して観測する形に直しています。利用側が実際に受け取るのは `OperationCanceledException` のままです。

## 検証

- `uloop compile` — エラー0・**SymphonyFrameWork 由来の警告0**
- PlayMode **9/9 を2回連続**（+5）、EditMode 222/222
- この Round の `.cs` はすべて UTF-8 BOM 付き

Play Mode での Sample を使った手動確認は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)