### PR TITLE
[update]Pauseのasync voidをAwaitableへ移行（3.0.0-preview.2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [3.0.0-preview.2] - 2026-08-04
+### Breaking
+- **`PauseManager.PausableDestroy` と `PausableInvoke` が `void` ではなく `Awaitable` を返すようになりました。**
+
+  **移行方法**: 文として呼んでいる場合、**ソースの変更は不要です。**
+
+  ```csharp
+  // 2.x でも 3.0.0 でもそのまま動く
+  PauseManager.PausableDestroy(gameObject, 1.0f);
+
+  // 3.0.0 では完了を待機できる
+  await PauseManager.PausableDestroy(gameObject, 1.0f);
+  ```
+
+  待機せずに呼んでも、破棄と処理の実行は従来どおり行われます。
+
+### Fix
+- **`PausableDestroy` と `PausableInvoke` の引数エラーが、呼び出し元へ同期的に伝わるようになりました。** 従来は `async void` だったため、`ArgumentNullException` や `ArgumentOutOfRangeException` が非同期メソッドの中で投げられ、呼び出し側の `try/catch` では捕まえられずUnityの未処理例外ハンドラへ流れていました。検証を同期部分へ移しています。
+
+### Add
+- `PausableInvoke` と `PausableDestroy` のPlayModeテストを5件追加した。待機した場合の実行、**待機せずに呼んでも実行されること**、引数エラーが同期的に投げられること、GameObjectの破棄を検証する。
+
+### 既知の代償
+- `Awaitable` は完了を観測した時点でプールへ返却されます。**待機せずに呼んだ場合はプールへ戻らず、通常のGC対象になります。** 無制限に溜まるものではなく、プールの効果が失われるだけです。fire-and-forgetとして使うAPIであるため、この代償を受け入れています。
+
 ## [3.0.0-preview.1] - 2026-08-04
 
 **3.0.0 系の最初のプレビューです。** 破壊的変更を段階的に積み上げ、Phase 5（Awaitable移行）とPhase 6（改名とシム削除）を終えた時点で `3.0.0` として確定します。プレビュー版は「壊れることを承知で先行して試す」ためのものです。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **3.0.0-preview.1**
+- 現在のバージョン: **3.0.0-preview.2**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること

--- a/Runtime/System/Pause/PauseManager.cs
+++ b/Runtime/System/Pause/PauseManager.cs
@@ -146,13 +146,18 @@ namespace SymphonyFrameWork.System
         }
 
         /// <summary>
-        ///     ポーズ中に停止するGameObjectのDestroy
+        ///     ポーズ中に停止するGameObjectのDestroy。
+        ///     待機せず呼び出しても破棄は実行される。
         /// </summary>
         /// <param name="obj"> 待機後に破棄するGameObject。 </param>
         /// <param name="t"> ポーズ時間を除いて待機する秒数。 </param>
         /// <param name="token"> 待機を中断するためのトークン。 </param>
-        public static async void PausableDestroy(GameObject obj, float t, CancellationToken token = default)
+        /// <returns> 破棄までの待機を表すAwaitable。 </returns>
+        /// <exception cref="ArgumentNullException"> objがnullの場合。 </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> tが負の場合。 </exception>
+        public static Awaitable PausableDestroy(GameObject obj, float t, CancellationToken token = default)
         {
+            // 検証は同期部分で行い、呼び出し元のtry/catchへ届くようにする。
             EnsureInitialized();
 
             if (obj == null)
@@ -161,19 +166,38 @@ namespace SymphonyFrameWork.System
             }
 
             ValidateDuration(t, nameof(t));
-            await PausableWaitForSecondAsync(t, token);
+
+            return DestroyAfterDelayAsync(obj, t, token);
+        }
+
+        /// <summary> 待機後にGameObjectを破棄する。 </summary>
+        /// <param name="obj"> 破棄するGameObject。 </param>
+        /// <param name="durationSeconds"> ポーズ時間を除いて待機する秒数。 </param>
+        /// <param name="token"> 待機を中断するためのトークン。 </param>
+        /// <returns> 破棄までの待機を表すAwaitable。 </returns>
+        private static async Awaitable DestroyAfterDelayAsync(
+            GameObject obj,
+            float durationSeconds,
+            CancellationToken token)
+        {
+            await PausableWaitForSecondAsync(durationSeconds, token);
 
             Object.Destroy(obj);
         }
 
         /// <summary>
-        ///     ポーズ中に停止するInvoke
+        ///     ポーズ中に停止するInvoke。
+        ///     待機せず呼び出しても処理は実行される。
         /// </summary>
         /// <param name="action"> 待機後に実行する処理。 </param>
         /// <param name="t"> ポーズ時間を除いて待機する秒数。 </param>
         /// <param name="token"> 待機を中断するためのトークン。 </param>
-        public static async void PausableInvoke(Action action, float t, CancellationToken token = default)
+        /// <returns> 実行までの待機を表すAwaitable。 </returns>
+        /// <exception cref="ArgumentNullException"> actionがnullの場合。 </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> tが負の場合。 </exception>
+        public static Awaitable PausableInvoke(Action action, float t, CancellationToken token = default)
         {
+            // 検証は同期部分で行い、呼び出し元のtry/catchへ届くようにする。
             EnsureInitialized();
 
             if (action == null)
@@ -182,9 +206,23 @@ namespace SymphonyFrameWork.System
             }
 
             ValidateDuration(t, nameof(t));
-            await PausableWaitForSecondAsync(t, token);
 
-            action?.Invoke();
+            return InvokeAfterDelayAsync(action, t, token);
+        }
+
+        /// <summary> 待機後に処理を実行する。 </summary>
+        /// <param name="action"> 実行する処理。 </param>
+        /// <param name="durationSeconds"> ポーズ時間を除いて待機する秒数。 </param>
+        /// <param name="token"> 待機を中断するためのトークン。 </param>
+        /// <returns> 実行までの待機を表すAwaitable。 </returns>
+        private static async Awaitable InvokeAfterDelayAsync(
+            Action action,
+            float durationSeconds,
+            CancellationToken token)
+        {
+            await PausableWaitForSecondAsync(durationSeconds, token);
+
+            action.Invoke();
         }
 
         /// <summary>

--- a/Tests/Runtime/PauseAwaitableRuntimeTests.cs
+++ b/Tests/Runtime/PauseAwaitableRuntimeTests.cs
@@ -117,6 +117,78 @@ namespace SymphonyFrameWork.Tests
             Assert.That(captured, Is.InstanceOf<OperationCanceledException>());
         }
 
+        /// <summary> PausableInvokeを待機すると、指定秒後に処理が実行されている。 </summary>
+        [UnityTest]
+        public IEnumerator PausableInvoke_Awaited_RunsAction()
+        {
+            bool invoked = false;
+            Task task = SymphonyAwaitable.AsTask(
+                PauseManager.PausableInvoke(() => invoked = true, 0.05f));
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            task.GetAwaiter().GetResult();
+            Assert.That(invoked, Is.True);
+        }
+
+        /// <summary>
+        ///     **待機せずに呼んでも処理は実行される。**
+        ///     fire-and-forgetとして使える契約を、Awaitableを返す形にしても保つ。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator PausableInvoke_NotAwaited_StillRunsAction()
+        {
+            bool invoked = false;
+
+            _ = PauseManager.PausableInvoke(() => invoked = true, 0.05f);
+
+            float startedAt = Time.realtimeSinceStartup;
+            yield return new WaitUntil(
+                () => invoked || Time.realtimeSinceStartup - startedAt > 2f);
+
+            Assert.That(invoked, Is.True);
+        }
+
+        /// <summary>
+        ///     **引数の誤りは同期的に投げられる。**
+        ///     async voidだった頃は非同期メソッド内で投げられ、呼び出し元の
+        ///     try/catchでは捕まえられなかった。
+        /// </summary>
+        [Test]
+        public void PausableInvoke_InvalidArguments_ThrowSynchronously()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => PauseManager.PausableInvoke(null, 0.05f));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => PauseManager.PausableInvoke(() => { }, -1f));
+        }
+
+        /// <summary> PausableDestroyは指定秒後にGameObjectを破棄する。 </summary>
+        [UnityTest]
+        public IEnumerator PausableDestroy_Awaited_DestroysObject()
+        {
+            var target = new GameObject(nameof(PausableDestroy_Awaited_DestroysObject));
+            Task task = SymphonyAwaitable.AsTask(
+                PauseManager.PausableDestroy(target, 0.05f));
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            task.GetAwaiter().GetResult();
+
+            // Destroyは次のフレームで反映される。
+            yield return null;
+
+            Assert.That(target == null, Is.True, "破棄されたGameObjectはnull相当になる。");
+        }
+
+        /// <summary> 破棄対象がnullなら同期的に例外になる。 </summary>
+        [Test]
+        public void PausableDestroy_NullObject_ThrowsSynchronously()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => PauseManager.PausableDestroy(null, 0.05f));
+        }
+
         /// <summary> PausableWaitUntilは条件成立で完了する。 </summary>
         [UnityTest]
         public IEnumerator PausableWaitUntil_CompletesWhenConditionMet()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.0.0-preview.1",
+  "version": "3.0.0-preview.2",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Round M1b。`PausableDestroy` と `PausableInvoke` を `async void` から `Awaitable` を返す形へ変更します。

設計書: `Documentation/Designs/AwaitableMigration.md`（ワークスペース側）

## M1 の判断を覆しました

M1 では「await されなかった例外が失われる」ことを理由に据え置きましたが、**構造を変えれば観測性はむしろ上がります。**

引数と初期化の検証を同期部分へ出し、待機と本処理だけを private な `async Awaitable` へ分けました。

```csharp
public static Awaitable PausableDestroy(GameObject obj, float t, CancellationToken token = default)
{
    // 検証は同期部分で行い、呼び出し元のtry/catchへ届くようにする。
    EnsureInitialized();
    if (obj == null) throw new ArgumentNullException(nameof(obj));
    ValidateDuration(t, nameof(t));

    return DestroyAfterDelayAsync(obj, t, token);
}
```

`async void` では `ArgumentNullException` すら非同期メソッドの中で投げられ、呼び出し側の `try/catch` では捕まえられず Unity の未処理例外ハンドラへ流れていました。**これは Fix として扱います。**

## 呼び出し側への影響

**文として呼んでいる限りソース変更は不要です。**

```csharp
// 2.x でも 3.0.0 でもそのまま動く
PauseManager.PausableDestroy(gameObject, 1.0f);

// 3.0.0 では完了を待機できる
await PauseManager.PausableDestroy(gameObject, 1.0f);
```

待機せずに呼んでも、破棄と処理の実行は従来どおり行われます。**テストで固定しました。**

## 既知の代償

`Awaitable` は完了を観測した時点でプールへ返却されます。**待機せずに呼んだ場合はプールへ戻らず、通常の GC 対象になります。** 無制限に溜まるものではなくプールの効果が失われるだけなので、fire-and-forget として使う API であることを踏まえて受け入れました。CHANGELOG に明記しています。

## 検証

- `uloop compile` — エラー0・**SymphonyFrameWork 由来の警告0**
- PlayMode **14/14 を2回連続**（+5）、EditMode 222/222
- 追加したテスト: 待機した場合の実行、**待機せずに呼んでも実行されること**、引数エラーが同期的に投げられること、GameObject の破棄
- この Round の `.cs` はすべて UTF-8 BOM 付き

Play Mode での Sample を使った手動確認は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)