### PR TITLE
[update]SaveStoreの非同期APIをAwaitableへ移行（3.0.0-preview.3）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [3.0.0-preview.3] - 2026-08-04
+### Breaking
+- **`SaveStore` の非同期API6件が `ValueTask` ではなく `Awaitable` を返すようになりました。** 対象は `LoadAsync<T>` / `LoadAsync(Type)` / `SaveAsync<T>` / `SaveAsync(Type)` / `DeleteAsync<T>` / `DeleteAsync(Type)` です。
+
+  **移行方法**: `await` して使っている場合、**ソースの変更は不要です。**
+
+  ```csharp
+  // 2.x でも 3.0.0 でもそのまま動く
+  await SaveStore.SaveAsync<PlayerData>();
+  PlayerData data = await SaveStore.LoadAsync<PlayerData>();
+  ```
+
+  `Task` や `ValueTask` として受けている場合は `SymphonyAwaitable.AsTask` で変換します。**`Awaitable` は1回しか `await` できず、保存も共有もできません。**
+
+  非推奨の `SaveDataRegistry` も同じ戻り値型になります。
+
+- **`SaveStore` の同期取得 `Get<T>()` の挙動は変わりません。** 内部の読み込み経路は `Task` のままです。
+
+### Change
+- **Symphony Administrator の Save Data パネルが Load / Save / Delete を非同期で実行するようになりました。** 従来は完了まで Editor のメインスレッドを止めていました。`Awaitable` を同期待機すると完了の伝播にメインスレッドが必要なためデッドロックするため、この変更は `Awaitable` 化と不可分です。
+
+### Add
+- `SaveStore` の非同期APIのPlayModeテストを6件追加した。保存と読み込みの往復、削除で既定値へ戻ること、キャンセル時の例外型、不正な型の同期例外を検証する。
+  - **同じ型へ続けて `LoadAsync` を呼んでも両方が完了すること**を回帰テストにした。内部は重複排除で1つの `Task` を共有するが、`Awaitable` は共有できないため呼び出しごとに別の `Awaitable` を作っている。この両立が壊れると、2回目の読み込みが返ってこなくなる。
+
 ## [3.0.0-preview.2] - 2026-08-04
 ### Breaking
 - **`PauseManager.PausableDestroy` と `PausableInvoke` が `void` ではなく `Awaitable` を返すようになりました。**

--- a/Editor/Administrator/UITK/CS/SaveDataRegistryWindow.cs
+++ b/Editor/Administrator/UITK/CS/SaveDataRegistryWindow.cs
@@ -89,9 +89,9 @@ namespace SymphonyFrameWork.Editor
             _editorContainer = root.Q<IMGUIContainer>("save-editor");
             _cacheListView = root.Q<ListView>("save-cache-list");
 
-            root.Q<Button>("save-load").clicked += () => ExecuteAction(LoadSelected);
-            root.Q<Button>("save-save").clicked += () => ExecuteAction(SaveSelected);
-            root.Q<Button>("save-delete").clicked += () => ExecuteAction(DeleteSelected);
+            root.Q<Button>("save-load").clicked += () => ExecuteActionAsync(LoadSelectedAsync);
+            root.Q<Button>("save-save").clicked += () => ExecuteActionAsync(SaveSelectedAsync);
+            root.Q<Button>("save-delete").clicked += () => ExecuteActionAsync(DeleteSelectedAsync);
 
             _editorContainer.onGUIHandler = DrawEditorInspector;
 
@@ -385,9 +385,10 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary> 選択中の型を保存先から再ロードして編集状態へ反映する。 </summary>
-        private void LoadSelected()
+        /// <returns> ロード完了までの待機を表すAwaitable。 </returns>
+        private async Awaitable LoadSelectedAsync()
         {
-            SaveStore.LoadAsync(_selectedType).GetAwaiter().GetResult();
+            await SaveStore.LoadAsync(_selectedType);
             SaveDataContent saveData = SaveStore.Get(_selectedType);
 
             RebindDebugState(saveData);
@@ -396,7 +397,8 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary> Inspectorの編集内容をレジストリ正本へ同期して保存する。 </summary>
-        private void SaveSelected()
+        /// <returns> 保存完了までの待機を表すAwaitable。 </returns>
+        private async Awaitable SaveSelectedAsync()
         {
             SaveDataContent editingData = _debugState.GetData();
             if (editingData == null)
@@ -414,7 +416,7 @@ namespace SymphonyFrameWork.Editor
                 JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(editingData), canonical);
             }
 
-            SaveStore.SaveAsync(_selectedType).GetAwaiter().GetResult();
+            await SaveStore.SaveAsync(_selectedType);
             SaveDataContent saveData = SaveStore.Get(_selectedType);
             RebindDebugState(saveData);
             _statusMessage = $"{_selectedType.FullName} を保存しました。";
@@ -422,8 +424,10 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary> 確認後に選択型の保存データを削除し、現在インスタンスを初期化する。 </summary>
-        private void DeleteSelected()
+        /// <returns> 削除完了までの待機を表すAwaitable。 </returns>
+        private async Awaitable DeleteSelectedAsync()
         {
+            // 確認ダイアログは同期のまま先に出し、承諾後だけ待機へ入る。
             if (!EditorUtility.DisplayDialog(
                     "Delete Save Data",
                     $"{_selectedType.FullName} の保存データを削除しますか？",
@@ -433,7 +437,7 @@ namespace SymphonyFrameWork.Editor
                 return;
             }
 
-            SaveStore.DeleteAsync(_selectedType).GetAwaiter().GetResult();
+            await SaveStore.DeleteAsync(_selectedType);
             SaveDataContent regenerated = SaveStore.Get(_selectedType);
             RebindDebugState(regenerated);
             _statusMessage = $"{_selectedType.FullName} の保存データを削除し、現在インスタンスを初期化しました。";
@@ -457,8 +461,13 @@ namespace SymphonyFrameWork.Editor
             _debugSerializedObject = new SerializedObject(_debugState);
         }
 
-        /// <summary> 選択状態を検証し、管理パネル操作中の例外をステータス表示へ変換する。 </summary>
-        private void ExecuteAction(Action action)
+        /// <summary>
+        ///     選択状態を検証し、管理パネル操作中の例外をステータス表示へ変換する。
+        ///     **Awaitableを同期待機するとEditorのメインスレッドが止まるため、非同期で実行する。**
+        ///     UIイベントからの呼び出しであり例外はここで捕捉するため、async voidでよい。
+        /// </summary>
+        /// <param name="operation"> 実行する非同期操作。 </param>
+        private async void ExecuteActionAsync(Func<Awaitable> operation)
         {
             if (_selectedType == null)
             {
@@ -469,10 +478,15 @@ namespace SymphonyFrameWork.Editor
 
             try
             {
-                action();
+                await operation();
             }
             catch (Exception ex)
             {
+                if (_disposed)
+                {
+                    return;
+                }
+
                 Debug.LogException(ex);
                 _statusMessage = ex.Message;
                 RefreshView();

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Symphony Frameworkは、Unityゲームで何度も作ることになる「シー
 最初のシーンより前に自動で初期化されるため、専用のBootstrapシーンやManagerプレハブを用意せず、必要な機能から使い始められます。
 
 - 対応Unity: **Unity 6（6000.0）以降**
-- 現在のバージョン: **3.0.0-preview.2**
+- 現在のバージョン: **3.0.0-preview.3**
 - ライセンス: **MIT**
 
 ## Symphony Frameworkでできること

--- a/Runtime/System/SaveSystem/Internal/Application/SaveDataService.cs
+++ b/Runtime/System/SaveSystem/Internal/Application/SaveDataService.cs
@@ -83,26 +83,26 @@ namespace SymphonyFrameWork.System.SaveSystem
         /// <summary> 指定型の永続化データをキャッシュへ非同期に読み込む。 </summary>
         /// <param name="dataType"> 対象のセーブデータ型。 </param>
         /// <param name="token"> 処理を中断するためのトークン。 </param>
-        /// <returns> 読み込みの完了を表すValueTask。 </returns>
-        public ValueTask LoadAsync(Type dataType, CancellationToken token = default)
+        /// <returns> 読み込みの完了を表すTask。 </returns>
+        public Task LoadAsync(Type dataType, CancellationToken token = default)
         {
             SaveDataEntryEntity entry = _registry.GetOrCreate(dataType);
 
             if (_registry.TryGetLoadingTask(dataType, out Task loadingTask))
             {
-                return new ValueTask(loadingTask);
+                return loadingTask;
             }
 
             Task loadTask = LoadInternalAsync(dataType, entry.Content, token);
             _registry.RegisterLoadingTaskIfPending(dataType, loadTask);
-            return new ValueTask(loadTask);
+            return loadTask;
         }
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <param name="dataType"> 対象のセーブデータ型。 </param>
         /// <param name="token"> 処理を中断するためのトークン。 </param>
-        /// <returns> 保存の完了を表すValueTask。 </returns>
-        public async ValueTask SaveAsync(Type dataType, CancellationToken token = default)
+        /// <returns> 保存の完了を表すTask。 </returns>
+        public async Task SaveAsync(Type dataType, CancellationToken token = default)
         {
             SaveDataEntryEntity entry = _registry.GetOrCreate(dataType);
             SaveDataContent content = entry.Content;
@@ -121,8 +121,8 @@ namespace SymphonyFrameWork.System.SaveSystem
         /// <summary> 指定型の永続化データを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <param name="dataType"> 対象のセーブデータ型。 </param>
         /// <param name="token"> 処理を中断するためのトークン。 </param>
-        /// <returns> 削除の完了を表すValueTask。 </returns>
-        public async ValueTask DeleteAsync(Type dataType, CancellationToken token = default)
+        /// <returns> 削除の完了を表すTask。 </returns>
+        public async Task DeleteAsync(Type dataType, CancellationToken token = default)
         {
             SaveDataEntryEntity entry = _registry.GetOrCreate(dataType);
             SaveDataContent content = entry.Content;

--- a/Runtime/System/SaveSystem/SaveDataRegistry.cs
+++ b/Runtime/System/SaveSystem/SaveDataRegistry.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using UnityEngine;
+
 namespace SymphonyFrameWork.System.SaveSystem
 {
     /// <summary>
@@ -35,37 +37,37 @@ namespace SymphonyFrameWork.System.SaveSystem
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask<T> LoadAsync<T>(CancellationToken token = default)
+        public static Awaitable<T> LoadAsync<T>(CancellationToken token = default)
             where T : SaveDataContent, new() => SaveStore.LoadAsync<T>(token);
 
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask LoadAsync(Type dataType, CancellationToken token = default) =>
+        public static Awaitable LoadAsync(Type dataType, CancellationToken token = default) =>
             SaveStore.LoadAsync(dataType, token);
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync<T>(CancellationToken token = default)
+        public static Awaitable SaveAsync<T>(CancellationToken token = default)
             where T : SaveDataContent, new() => SaveStore.SaveAsync<T>(token);
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync(Type dataType, CancellationToken token = default) =>
+        public static Awaitable SaveAsync(Type dataType, CancellationToken token = default) =>
             SaveStore.SaveAsync(dataType, token);
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask DeleteAsync<T>(CancellationToken token = default)
+        public static Awaitable DeleteAsync<T>(CancellationToken token = default)
             where T : SaveDataContent, new() => SaveStore.DeleteAsync<T>(token);
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask DeleteAsync(Type dataType, CancellationToken token = default) =>
+        public static Awaitable DeleteAsync(Type dataType, CancellationToken token = default) =>
             SaveStore.DeleteAsync(dataType, token);
 
         /// <summary>

--- a/Runtime/System/SaveSystem/SaveStore.cs
+++ b/Runtime/System/SaveSystem/SaveStore.cs
@@ -4,6 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using SymphonyFrameWork.Exceptions;
+using SymphonyFrameWork.Utility;
+
+using UnityEngine;
 
 namespace SymphonyFrameWork.System.SaveSystem
 {
@@ -49,53 +52,69 @@ namespace SymphonyFrameWork.System.SaveSystem
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static async ValueTask<T> LoadAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
+        public static Awaitable<T> LoadAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new()
         {
-            await LoadAsync(typeof(T), token);
-            return Get<T>();
+            ValidateDataType(typeof(T));
+            SaveDataService service = EnsureInitialized();
+
+            return SymphonyAwaitable.FromTask(LoadAndGetAsync<T>(service, token));
         }
 
         /// <summary> 指定型の保存済みデータをキャッシュへ非同期に読み込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask LoadAsync(Type dataType, CancellationToken token = default)
+        public static Awaitable LoadAsync(Type dataType, CancellationToken token = default)
         {
             ValidateDataType(dataType);
-            return EnsureInitialized().LoadAsync(dataType, token);
+
+            // 重複ロード中は同じTaskが返るが、FromTaskが呼び出しごとに新しい
+            // Awaitableを作るため、Awaitableを共有できないという制約と両立する。
+            return SymphonyAwaitable.FromTask(EnsureInitialized().LoadAsync(dataType, token));
         }
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
-        {
-            return SaveAsync(typeof(T), token);
-        }
+        public static Awaitable SaveAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new() => SaveAsync(typeof(T), token);
 
         /// <summary> 指定型のキャッシュを保存先へ非同期に書き込む。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で保存に失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask SaveAsync(Type dataType, CancellationToken token = default)
+        public static Awaitable SaveAsync(Type dataType, CancellationToken token = default)
         {
             ValidateDataType(dataType);
-            return EnsureInitialized().SaveAsync(dataType, token);
+            return SymphonyAwaitable.FromTask(EnsureInitialized().SaveAsync(dataType, token));
         }
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static async ValueTask DeleteAsync<T>(CancellationToken token = default) where T : SaveDataContent, new()
-        {
-            await DeleteAsync(typeof(T), token);
-        }
+        public static Awaitable DeleteAsync<T>(CancellationToken token = default)
+            where T : SaveDataContent, new() => DeleteAsync(typeof(T), token);
 
         /// <summary> 指定型の保存済みデータを削除し、キャッシュを既定値へ戻す。 </summary>
         /// <exception cref="SaveDataOperationException"> ローダーまたは保存先で削除または再読み込みに失敗した場合。 </exception>
         /// <exception cref="OperationCanceledException"> 呼び出し側から処理が中断された場合。 </exception>
-        public static ValueTask DeleteAsync(Type dataType, CancellationToken token = default)
+        public static Awaitable DeleteAsync(Type dataType, CancellationToken token = default)
         {
             ValidateDataType(dataType);
-            return EnsureInitialized().DeleteAsync(dataType, token);
+            return SymphonyAwaitable.FromTask(EnsureInitialized().DeleteAsync(dataType, token));
+        }
+
+        /// <summary> 読み込み完了後のインスタンスを返す。 </summary>
+        /// <typeparam name="T"> 対象のセーブデータ型。 </typeparam>
+        /// <param name="service"> 処理を委譲するService。 </param>
+        /// <param name="token"> 処理を中断するためのトークン。 </param>
+        /// <returns> 読み込み後のインスタンス。 </returns>
+        private static async Task<T> LoadAndGetAsync<T>(
+            SaveDataService service,
+            CancellationToken token)
+            where T : SaveDataContent, new()
+        {
+            await service.LoadAsync(typeof(T), token);
+            return (T)service.Get(typeof(T));
         }
 
         /// <summary>

--- a/Tests/Runtime/SaveStoreAwaitableRuntimeTests.cs
+++ b/Tests/Runtime/SaveStoreAwaitableRuntimeTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using SymphonyFrameWork.System.SaveSystem;
+using SymphonyFrameWork.Utility;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary>
+    ///     SaveStoreの非同期APIがAwaitableへ移行しても、往復と重複排除の契約を
+    ///     保つことを検証する。SaveStoreはPlay Mode開始時に初期化される。
+    /// </summary>
+    public sealed class SaveStoreAwaitableRuntimeTests
+    {
+        /// <summary> 検証用のセーブデータ型。 </summary>
+        [Serializable]
+        public sealed class AwaitableTestSaveData : SaveDataContent
+        {
+            public int Value;
+        }
+
+        /// <summary> 検証で書き込んだ保存データを消し、次のテストへ持ち越さない。 </summary>
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            Task task = SymphonyAwaitable.AsTask(
+                SaveStore.DeleteAsync<AwaitableTestSaveData>());
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            // 削除自体の失敗はテスト対象ではないため、例外は観測して捨てる。
+            _ = task.Exception;
+        }
+
+        /// <summary> 保存した値が読み込みで戻る。 </summary>
+        [UnityTest]
+        public IEnumerator SaveAsync_ThenLoadAsync_RoundTripsValue()
+        {
+            SaveStore.Get<AwaitableTestSaveData>().Value = 42;
+
+            Task saveTask = SymphonyAwaitable.AsTask(
+                SaveStore.SaveAsync<AwaitableTestSaveData>());
+            yield return new WaitUntil(() => saveTask.IsCompleted);
+            saveTask.GetAwaiter().GetResult();
+
+            SaveStore.Get<AwaitableTestSaveData>().Value = 0;
+
+            Task<AwaitableTestSaveData> loadTask = SymphonyAwaitable.AsTask(
+                SaveStore.LoadAsync<AwaitableTestSaveData>());
+            yield return new WaitUntil(() => loadTask.IsCompleted);
+
+            AwaitableTestSaveData loaded = loadTask.GetAwaiter().GetResult();
+            Assert.That(loaded.Value, Is.EqualTo(42));
+        }
+
+        /// <summary> 削除で既定値へ戻る。 </summary>
+        [UnityTest]
+        public IEnumerator DeleteAsync_ResetsToDefault()
+        {
+            SaveStore.Get<AwaitableTestSaveData>().Value = 7;
+
+            Task saveTask = SymphonyAwaitable.AsTask(
+                SaveStore.SaveAsync<AwaitableTestSaveData>());
+            yield return new WaitUntil(() => saveTask.IsCompleted);
+            saveTask.GetAwaiter().GetResult();
+
+            Task deleteTask = SymphonyAwaitable.AsTask(
+                SaveStore.DeleteAsync<AwaitableTestSaveData>());
+            yield return new WaitUntil(() => deleteTask.IsCompleted);
+            deleteTask.GetAwaiter().GetResult();
+
+            Assert.That(SaveStore.Get<AwaitableTestSaveData>().Value, Is.Zero);
+        }
+
+        /// <summary>
+        ///     **同じ型へ続けてLoadAsyncを呼んでも両方が完了する。**
+        ///     内部は重複排除で1つのTaskを共有するが、Awaitableは共有できないため
+        ///     呼び出しごとに別のAwaitableを作っている。その両立の回帰テスト。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator LoadAsync_CalledTwice_BothComplete()
+        {
+            Task first = SymphonyAwaitable.AsTask(
+                SaveStore.LoadAsync(typeof(AwaitableTestSaveData)));
+            Task second = SymphonyAwaitable.AsTask(
+                SaveStore.LoadAsync(typeof(AwaitableTestSaveData)));
+
+            yield return new WaitUntil(() => first.IsCompleted && second.IsCompleted);
+
+            first.GetAwaiter().GetResult();
+            second.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///     キャンセル済みトークンではOperationCanceledExceptionになる。
+        ///     Awaitableを直接awaitして、利用側が受け取る型を観測する。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator SaveAsync_Canceled_ThrowsOperationCanceled()
+        {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            Exception captured = null;
+
+            async Task AwaitDirectlyAsync()
+            {
+                try
+                {
+                    await SaveStore.SaveAsync<AwaitableTestSaveData>(cancellation.Token);
+                }
+                catch (Exception exception)
+                {
+                    captured = exception;
+                }
+            }
+
+            Task task = AwaitDirectlyAsync();
+
+            yield return new WaitUntil(() => task.IsCompleted);
+
+            Assert.That(captured, Is.InstanceOf<OperationCanceledException>());
+        }
+
+        /// <summary> 不正な型は同期的に例外になる。 </summary>
+        [Test]
+        public void LoadAsync_NullType_ThrowsSynchronously()
+        {
+            Assert.Throws<ArgumentNullException>(() => SaveStore.LoadAsync(null));
+        }
+    }
+}

--- a/Tests/Runtime/SaveStoreAwaitableRuntimeTests.cs.meta
+++ b/Tests/Runtime/SaveStoreAwaitableRuntimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2eb4c8ba2b00b594ebeb00ad02297fc1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.0.0-preview.2",
+  "version": "3.0.0-preview.3",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Round M2。`SaveStore` の非同期API6件を `Awaitable` へ移行します。

設計書: `Documentation/Designs/AwaitableMigration.md`（ワークスペース側）

## 重複ロード排除と Awaitable を両立させました

`Awaitable` は**1回しか await できず、共有できません**。一方、`SaveDataService._loadingTasks` は進行中ロードの重複排除のため**複数の呼び出し元へ同じ待機を返します**（Round I1 で回帰テストを書いた不変条件）。

内部は `Task` のまま共有し、`SymphonyAwaitable.FromTask` が**呼び出しごとに新しい `Awaitable` を作る**ことで両立させました。

```csharp
public static Awaitable LoadAsync(Type dataType, CancellationToken token = default)
{
    ValidateDataType(dataType);

    // 重複ロード中は同じTaskが返るが、FromTaskが呼び出しごとに新しい
    // Awaitableを作るため、Awaitableを共有できないという制約と両立する。
    return SymphonyAwaitable.FromTask(EnsureInitialized().LoadAsync(dataType, token));
}
```

**「同じ型へ続けて `LoadAsync` を呼んでも両方が完了する」を回帰テストにしました。** ここが壊れると2回目の読み込みが返ってこなくなります。

## Editor パネルの非同期化は不可分でした

`SaveDataRegistryWindow` が `SaveStore` の3メソッドで `.GetAwaiter().GetResult()` していました。**`Awaitable` を同期待機すると、完了の伝播にメインスレッドが必要なためデッドロックします。**

Load / Save / Delete を `async Awaitable` にし、`ExecuteActionAsync(Func<Awaitable>)` で例外をステータス表示へ変換します。従来は完了まで Editor のメインスレッドを止めていたので、この点は改善でもあります。

## 内部の同期ブロックは残しました

`SaveDataService.Get`（同期取得）は `LoadAsync(...).GetAwaiter().GetResult()` を呼びます。**内部を `Task` のまま保ったため `Awaitable` を挟まず、デッドロックしません。** 同梱ローダーは同期完了するため挙動も従来どおりです。

## 拡張点は次の Round

`SaveDataLoaderStrategy` の `protected abstract` メンバーの `Awaitable` 化は **Round M2b** とします。上記の同期ブロック経路と相互作用するため、単独で検証したいためです。

## 検証

- `uloop compile` — エラー0・**SymphonyFrameWork 由来の警告0**
- PlayMode **19/19 を2回連続**（+5）、EditMode 222/222
- この Round の `.cs` はすべて UTF-8 BOM 付き

**Symphony Administrator の Save Data パネルで Load / Save / Delete を実行し、Editor が固まらないことの手動確認は未実施です。** 本 PR で最も確認していただきたい点です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)