### PR TITLE
[add]Editor機能と削除予定のドキュメントを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@
 | 機能、インストール、初期設定を知る | [README.md](./README.md)の「主な機能」「インストール」「初期設定」 |
 | Service Locator、Scene Loader、Save Data、Audio、Pauseを使う | [README.md](./README.md)の該当クイックスタート → [AgentUsage.md](./Documentation~/AgentUsage.md)の該当モジュール |
 | アセンブリ、フォルダ、初期化順、公開型の関係を調べる | [Architecture.md](./Documentation~/Architecture.md) |
-| Editor・デバッグ機能を使う | [README.md `Editor・デバッグ支援`](./README.md#editorデバッグ支援) |
+| Editor・デバッグ機能を使う | [EditorTools.md](./Documentation~/EditorTools.md)。索引だけなら[README.md `Editor・デバッグ支援`](./README.md#editorデバッグ支援) |
 | 利用コードをコンパイル・Play Mode・ビルドで確認する | [AgentVerification.md](./Documentation~/AgentVerification.md) |
-| バージョン差分、非推奨化、移行方法を調べる | [CHANGELOG.md](./CHANGELOG.md) |
+| 非推奨APIと移行方法、削除予定を調べる | [Deprecations.md](./Documentation~/Deprecations.md) |
+| バージョン差分の経緯を調べる | [CHANGELOG.md](./CHANGELOG.md) |
 | フレームワーク本体を開発・変更する | [SymphonyWorkspaceのCONTRIBUTING.md](https://github.com/HIBIKI5201/SymphonyWorkspace/blob/dev/Documentation/CONTRIBUTING.md) |
 
 ## 1. 常に守ること

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [3.2.1] - 2026-08-05
+Editor機能と非推奨APIのドキュメントを追加しました。**コードは変更していません。** 公開API、シリアライズ形式、挙動のいずれも 3.2.0 と同じです。
+
+### Add
+
+- **`Documentation~/EditorTools.md` を追加しました。** Editor機能の正本です。
+
+  これまでEditor機能の説明は README の `Editor・デバッグ支援` にある10行の箇条書きだけで、**`AssetStoreToolsPackager`、`SymphonyPackageLoader`、`SymphonyAssetProtector`、`SymphonyMcpTools`、Project Settings の各設定項目は1行も書かれていませんでした。** Runtime の各サブシステムには README のクイックスタートがあるのに、Editor機能には対応する正本がありませんでした。
+
+  `Editor/` 配下の全モジュールについて、何をするものか、どのメニューやProject Settingsから開くか、設定がどこへ保存されるか、版管理へ含めるべきかを記載しています。README の箇条書きは索引として残し、詳細はこちらへ委譲します。
+
+- **`Documentation~/Deprecations.md` を追加しました。** 非推奨APIと削除予定の正本です。
+
+  非推奨APIの正本はこれまで CHANGELOG でしたが、CHANGELOG は時系列の記録であり、**「今なお非推奨で、まだ消えていないもの」を一覧できません。** 非推奨化した版まで遡って読む必要があり、その後で削除されたのかどうかも分かりませんでした。
+
+  現在7件の `[Obsolete]` メンバーがあり、そのうち**6件は非推奨化がCHANGELOGへ記載されておらず、削除予定も決まっていません**（`SymphonyDebugLogger` の4件と `SymphonyTween` の2件）。この文書では削除予定を「未定」と明記し、判断が必要な項目が残っていること自体が見えるようにしています。
+
+### Change
+
+- `Documentation~/AgentUsage.md` の「非推奨APIの期限と移行先は CHANGELOG.md を正本とします」を、`Deprecations.md` を正本とする記述へ変更しました。正本が2つになることを避けるためです。非推奨化の経緯と時期は引き続き CHANGELOG を参照します。
+
+- `AGENTS.md` の参照先表で、Editor・デバッグ機能の参照先を `EditorTools.md` へ、非推奨APIと移行方法の参照先を `Deprecations.md` へ変更しました。
+
 ## [3.2.0] - 2026-08-04
 Asset Store Tools Packager に、出力前の確認ウィンドウを追加しました。**Runtime の公開APIとセーブデータ形式は変更していません。**
 

--- a/Documentation~/AgentUsage.md
+++ b/Documentation~/AgentUsage.md
@@ -71,4 +71,4 @@
 
 ## 非推奨APIと移行
 
-非推奨APIの期限と移行先は[CHANGELOG.md](../CHANGELOG.md)を正本とします。古いコードを修正するときは、現在のバージョンのソースとCHANGELOGを確認し、過去バージョンのnamespaceやAPI一覧をこの文書へ固定しないでください。
+非推奨APIの移行先と削除予定は[Deprecations.md](./Deprecations.md)を正本とします。非推奨化した経緯と時期は[CHANGELOG.md](../CHANGELOG.md)を参照してください。古いコードを修正するときは、現在のバージョンのソースとこの2つを確認し、過去バージョンのnamespaceやAPI一覧をこの文書へ固定しないでください。

--- a/Documentation~/Deprecations.md
+++ b/Documentation~/Deprecations.md
@@ -1,0 +1,62 @@
+# 非推奨APIと削除予定
+
+`[Obsolete]` を付けた公開APIと、その削除予定の一覧です。**「今なお非推奨で、まだ消えていないもの」の正本**として扱います。
+
+[CHANGELOG.md](../CHANGELOG.md)との分担:
+
+| 文書 | 役割 |
+| --- | --- |
+| CHANGELOG.md | **時系列の記録。** どの版で非推奨にしたか、どの版で削除したか |
+| この文書 | **現在形の一覧。** 今どれが非推奨で、いつ消えるのか |
+
+CHANGELOGだけでは、非推奨化した版まで遡らないと一覧できず、その後で削除されたのかも分かりません。非推奨化のたびに両方へ書きます。
+
+---
+
+## 削除予定の一覧
+
+| 対象 | 場所 | 移行先 | 非推奨にした版 | 削除予定 | 備考 |
+| --- | --- | --- | --- | --- | --- |
+| `SymphonyDebugLogger.DirectLog(string, LogKindEnum)` | `Runtime/Debug/SymphonyDebugLogger.cs` | `SymphonyDebugLogger.LogDirect` | 記録なし | **未定** | 非推奨にした版がCHANGELOGから特定できていない |
+| `SymphonyDebugLogger.TextLog(LogKindEnum, bool)` | `Runtime/Debug/SymphonyDebugLogger.cs` | `SymphonyDebugLogger.LogText` | 記録なし | **未定** | 同上 |
+| `SymphonyDebugLogger.CheckComponentNull<T>(T)` | `Runtime/Debug/SymphonyDebugLogger.cs` | `SymphonyDebugLogger.LogAndCheckComponentNull` | 記録なし | **未定** | 拡張メソッド。同上 |
+| `SymphonyDebugLogger.IsComponentNotNull<T>(T)` | `Runtime/Debug/SymphonyDebugLogger.cs` | `SymphonyDebugLogger.LogAndCheckComponentNull` | 記録なし | **未定** | 拡張メソッド。「安全性が保障されていない」ことを理由に非推奨化されている。同上 |
+| `SymphonyTween.TweeningLerp<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | `Task` を返す旧型式。移行先は `Awaitable` を返す |
+| `SymphonyTween.TweeningCurve<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | 同上 |
+| `EditorSymphonyConstant.ASSET_STORE_TOOLS_IGNORE_FILE` | `Core/Editor/EditorSymphonyConstant.cs` | `EditorSymphonyConstant.ASSET_STORE_TOOLS_CONFIG_FILE_NAME` | 3.1.0 | 次のメジャー更新 | 削除時は `AssetStoreToolsPackagerConfigStore` の `ignore.txt` 移行処理（`IGNORE_FILE_NAME`、`ReadIgnoreFile`、`CreateConfigFile` の移行分岐）も一緒に削除する |
+
+### 「未定」について
+
+**削除予定が「未定」の項目は、判断がまだ行われていないことを表します。** 空欄にせず未定と書くのは、判断が必要な項目が何件あるかを見えるようにするためです。
+
+現在6件が未定です。**CHANGELOGの `### Deprecated` 節をすべて確認しましたが、これら6件の非推奨化はどの版にも記載がありませんでした。** 記載があるのは `SaveDataLoader`（2.20.0）、`SaveDataRegistry`（2.19.0）、`SymphonyTask`（2.6.0）、旧namespaceのFacade（2.2.0）、`ASSET_STORE_TOOLS_IGNORE_FILE`（3.1.0）で、いずれも別の対象です。
+
+非推奨化がCHANGELOGへ記載されないまま残っていたことが、この文書を作った理由の1つです。次のメジャー更新を計画するときに、6件の削除時期をまとめて判断してください。
+
+---
+
+## 削除の方針
+
+- **`[Obsolete]` を付けたら、同じ変更でこの文書へ行を追加します。** 削除予定が決まっていない場合は「未定」と書きます。書かずに済ませないでください。
+- 非推奨化と同時に、CHANGELOGの `### Deprecated` へ移行方法を書きます。
+- **削除は必ずメジャー更新で行います。** `public` / `protected` メンバーの削除は破壊的変更です。
+- 削除したら、この文書の行を[削除済み](#削除済み)へ移し、CHANGELOGの `### Breaking` へ移行方法を書きます。
+- 名前・シグネチャ・意味が同時に変わり、旧契約を安全に維持できないAPIは `[Obsolete]` のシムを残さず、メジャー更新で直接削除します。その場合も、削除予定としてこの文書へ先に載せます。
+
+`[Obsolete]` は `error: false`（警告）で付けます。利用側のコンパイルを止めず、移行期間を確保するためです。
+
+---
+
+## 削除済み
+
+削除が完了したものをここへ移します。移行が終わっているかの確認に使ってください。
+
+現時点で削除済みの項目はありません。3.0.0での破壊的変更は[CHANGELOG.md](../CHANGELOG.md)の `### Breaking` を参照してください。
+
+---
+
+## 関連ドキュメント
+
+- [CHANGELOG.md](../CHANGELOG.md) — 変更履歴。非推奨化・削除の時系列
+- [README.md](../README.md) — 現行APIのクイックスタート
+- [AgentUsage.md](./AgentUsage.md) — AIエージェントが利用コードを書くときの注意事項

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -1,0 +1,351 @@
+# Editor機能
+
+Symphony Frameworkが提供するEditor拡張の正本です。何をするもので、どこから開き、設定がどこに保存されるかを記載します。
+
+Runtime APIの使い方は[README.md](../README.md)のクイックスタートを参照してください。アセンブリ構成と初期化順は[Architecture.md](./Architecture.md)にあります。
+
+Editor機能はGUI操作を入口とするため、この文書にコード例は載せません。
+
+## 一覧
+
+メニューの基準パスは `Tools/SymphonyFrameWork/`、ウィンドウは `Window/SymphonyFrameWork/`、Project Settingsは `SymphonyFrameWork` です。
+
+| 機能 | 入口 |
+| --- | --- |
+| [Symphony Administrator](#symphony-administrator) | `Window > SymphonyFrameWork > Symphony Administrator` |
+| [Framework設定](#framework設定) | `Project Settings > SymphonyFrameWork` |
+| [Save System設定](#save-system設定) | `Project Settings > SymphonyFrameWork > Save System` |
+| [Asset Store Tools Packager設定](#asset-store-tools-packager設定) | `Project Settings > SymphonyFrameWork > Asset Store Tools Packager` |
+| [Asset Store Tools Packager](#asset-store-tools-packager) | `Tools > SymphonyFrameWork > ExportAssetStoreToolsFolder` |
+| [AutoEnumGenerator](#autoenumgenerator) | 自動実行。手動生成はSymphony Administratorから |
+| [FolderGenerator](#foldergenerator) | `Tools > SymphonyFrameWork > FolderGenerator` |
+| [AssemblyGenerator](#assemblygenerator) | メニューなし。他のEditor機能から呼ばれる |
+| [SymphonyPackageLoader](#symphonypackageloader) | `Tools > SymphonyFrameWork > SymphonyPackageLoader` |
+| [SymphonyDebugHUD](#symphonydebughud) | `Tools > SymphonyFrameWork > SymphonyDebugHUD > Show` / `Hide` |
+| [ログのファイル出力](#ログのファイル出力) | 自動実行 |
+| [SymphonyMcpTools](#symphonymcptools) | メニューなし。外部ツールから呼ぶ |
+| [アセット保護](#アセット保護) | 自動実行。強さは`Project Settings > SymphonyFrameWork` |
+| [Inspector属性](#inspector属性) | 利用側のフィールドへ属性を付ける |
+| [設定アセットの自動生成](#設定アセットの自動生成) | 自動実行 |
+| [Editorの初期化](#editorの初期化) | 自動実行 |
+
+### 設定ファイルの置き場
+
+| ファイル | 内容 | 版管理 |
+| --- | --- | --- |
+| `ProjectSettings/Packages/symphonyframework/AutoEnumGeneratorConfig.asset` | enum自動生成の有効・無効 | 含める（プロジェクト共有） |
+| `ProjectSettings/Packages/symphonyframework/AssetStoreToolsPackagerData.asset` | Packagerの入出力パス | 含める（プロジェクト共有） |
+| `UserSettings/SymphonyFrameWork/SymphonyUserSettingConfig.asset` | アセット保護の強さ、Service Locatorのログ設定 | **含めない（開発者ごと）** |
+| `Assets/Resources/SymphonyFrameWork/*.asset` | `SceneLoadConfig` / `AudioConfig` / `SaveDataConfig` | 含める |
+| `<Asset Store Tools Path>/PackagerConfig.json` | Packagerの除外フォルダと強制包含拡張子 | 含める |
+| `<Frameworkルート>/Cache/Log.txt` | `SymphonyDebugLogger`の出力 | **含めない（生成物）** |
+
+---
+
+## Symphony Administrator
+
+Frameworkの各サブシステムの状態を1つのウィンドウで確認する管理パネルです。UI Toolkitで構成されています。
+
+**入口**: `Window > SymphonyFrameWork > Symphony Administrator`
+
+**パネル**:
+
+| パネル | 内容 |
+| --- | --- |
+| Service Locate | 登録済みインスタンスの一覧と登録状態 |
+| Scene Load | ロード済みシーンと進行中のロード |
+| Save Data | セーブデータの登録内容 |
+| Pause | ポーズ状態の確認と切り替え |
+| Auto Enum Generator | enumの手動生成ボタンと自動生成の有効・無効 |
+
+**注意点**:
+
+- Runtimeの状態を表示するパネルは、Play Mode中のみ内容を持ちます。Edit Modeでは未接続状態を表示します。
+- 表示はViewModelの変更通知で更新されます。ウィンドウを開いている間のポーリングは行いません。
+
+---
+
+## Framework設定
+
+Framework全体の開発者ごとの設定です。
+
+**入口**: `Project Settings > SymphonyFrameWork`
+
+**項目**:
+
+| 項目 | 内容 |
+| --- | --- |
+| Asset Protection Mode | Framework配下のアセット移動に対する保護の強さ。`Enabled` / `Warning` / `Disabled` |
+| Service Locatorのログ設定 | インスタンスの登録ログ・取得ログをそれぞれ出力するか |
+
+**保存先**: `UserSettings/SymphonyFrameWork/SymphonyUserSettingConfig.asset`
+
+**注意点**:
+
+- `UserSettings/` は開発者ごとの設定です。**版管理へ含めないでください。** 他の開発者の保護モードやログ設定を上書きします。
+
+---
+
+## Save System設定
+
+`SaveStore` が使用するセーブローダーを選択します。
+
+**入口**: `Project Settings > SymphonyFrameWork > Save System`
+
+**項目**:
+
+| 項目 | 内容 |
+| --- | --- |
+| Loader | `SaveDataLoaderStrategy` を継承したローダー。`[SerializeReference]` で選択する |
+| Current Loader Type | 現在設定されているローダーの型名（読み取り専用） |
+
+**保存先**: `Assets/Resources/SymphonyFrameWork/SaveDataConfig.asset`
+
+**注意点**:
+
+- ローダーが未設定の場合、`SaveStore` は既定の `JsonUtility` ローダーへフォールバックします。警告が表示されます。
+- 独自ローダーは `SaveDataLoaderStrategy` を継承してください。共通の検証とデータ復旧は基底クラスが担当します。
+- ローダーを変更すると、その場で `SaveStore` が読み直します。
+
+---
+
+## Asset Store Tools Packager設定
+
+Packagerが使う入出力パスと、パッケージへ何を詰めるかの設定です。
+
+**入口**: `Project Settings > SymphonyFrameWork > Asset Store Tools Packager`
+
+**項目**:
+
+| 項目 | 内容 | 保存先 |
+| --- | --- | --- |
+| Asset Store Tools Path | パッケージ化の対象となるフォルダ。既定は `Assets/AssetStoreTools` | `ProjectSettings/Packages/symphonyframework/AssetStoreToolsPackagerData.asset` |
+| Exported Packages Path | 出力先フォルダ。既定は `ExportedPackages` | 同上 |
+| Ignored Directories | パッケージ対象から除外するフォルダ名 | `<Asset Store Tools Path>/PackagerConfig.json` |
+| Force Include Extensions | 依存関係に載らなくても必ず含める拡張子 | 同上 |
+
+**設定の分担**: 「どこにあるか」（パス）がProject Settings、「何を詰めるか」（除外・強制包含）が `PackagerConfig.json` です。`PackagerConfig.json` は `Assets/` 配下にあるため、利用側のリポジトリで版管理し、手で編集できます。
+
+**注意点**:
+
+- `Asset Store Tools Path` を変更しても `PackagerConfig.json` は自動で読み直されません。`Reload` ボタンで明示的に読み込んでください。入力途中のパスごとに設定ファイルを生成しないための仕様です。
+- `Force Include Extensions` の既定値には `.cs` / `.asmdef` / `.asmref` と、ネイティブプラグインのバイナリ（`.dll` / `.so` / `.a` / `.dylib` / `.aar` / `.bundle` / `.framework` / `.jslib`）が入っています。`.asmdef` と `.asmref` はUnityの依存関係グラフに載らないため、ここに無いとパッケージから落ちます。
+
+---
+
+## Asset Store Tools Packager
+
+`Asset Store Tools Path` 配下の各フォルダを `.unitypackage` として出力します。Asset Store由来のアセットを別プロジェクトへ持ち込むためのツールです。
+
+**入口**: `Tools > SymphonyFrameWork > ExportAssetStoreToolsFolder`
+
+**操作**:
+
+1. 出力するフォルダをチェックボックスで選ぶ。`PackagerConfig.json` の `Ignored Directories` に入っているフォルダは `(Ignored)` と表示され、選択できません
+2. 出力形式を選ぶ
+
+   | 項目 | 内容 |
+   | --- | --- |
+   | Export Mode `Singles` | 選んだフォルダを個別の `.unitypackage` として出力する |
+   | Export Mode `Combine` | 選んだフォルダを1つの `.unitypackage` にまとめて出力する |
+   | Create ZIP File | 出力フォルダ全体をZIP化する |
+   | Used Dependencies | プロジェクト内で実際に使用しているアセットと、強制包含拡張子だけに絞る |
+
+3. `Export Selected Directories` を押すと、**出力せずに確認ウィンドウが開きます。** パッケージへ含まれるアセットが階層表示されます
+4. `Export` で実行、`Cancel` で中止
+
+**出力先**: `<Exported Packages Path>/Export_AssetStoreToolsPackage_<日時>/`
+
+**注意点**:
+
+- 確認ウィンドウで「（対象アセットなし）」と表示されたフォルダは、出力時に警告になります。`Used Dependencies` を有効にしていて、そのフォルダのアセットがプロジェクト内で1つも使われていない場合に起きます。
+- `Used Dependencies` は `AssetDatabase.GetDependencies` で依存関係を追います。この依存関係グラフに載らないファイル（`.asmdef` など）は `Force Include Extensions` で補います。
+- `.bundle` と `.framework` はUnityが単一アセットとして扱うため、フォルダに見えても中身のファイルではなくフォルダごと出力されます。
+
+---
+
+## AutoEnumGenerator
+
+Build Settingsのシーン一覧、タグ、レイヤー、Audio Groupの変更を検知して、対応するenumを自動生成します。
+
+**入口**: 自動実行。手動生成はSymphony Administratorの `Auto Enum Generator` パネルから
+
+**生成物**: `Assets/Scripts/SymphonyFrameWork/`
+
+| ファイル | 生成元 |
+| --- | --- |
+| `SceneListEnum.cs` | Build Settingsのシーン一覧（**登録順が値になります**） |
+| `TagsEnum.cs` | `ProjectSettings/TagManager.asset` のタグ |
+| `LayersEnum.cs` | 同上のレイヤー（フラグenum） |
+| `AudioGroupTypeEnum.cs` | `AudioConfig` のグループ名 |
+| `SymphonyFrameWork.Enum.asmdef` | 上記を含むアセンブリ |
+
+**設定**: `ProjectSettings/Packages/symphonyframework/AutoEnumGeneratorConfig.asset`。シーン・タグ・レイヤーそれぞれについて自動更新の有効・無効を切り替えられます。
+
+**変更の検知**: `TagsAndLayersPostProcessor`（`AssetPostprocessor`）がタグ・レイヤー設定ファイルの変更を、`EditorBuildSettings.sceneListChanged` がシーン一覧の変更を検知します。検知した変更は `SymphonyEditorOrchestrator` へ通知され、まとめて1回処理されます。
+
+**注意点**:
+
+- **生成されたenumを手で編集しないでください。** 再生成で失われます。
+- 利用側のasmdefから生成enumを直接使う場合は、`SymphonyFrameWork.Enum` を参照に追加してください。
+- `SymphonyFrameWork.asmdef` から `SymphonyFrameWork.Enum` への参照は、Editor起動時に自動で注入されます。
+
+---
+
+## FolderGenerator
+
+Markdownで定義したフォルダ構成を `Assets/` 配下へ生成します。プロジェクト開始時の雛形づくりに使います。
+
+**入口**: `Tools > SymphonyFrameWork > FolderGenerator`
+
+**定義ファイル**: `<Frameworkルート>/Editor/Generator/FolderGenerate/FolderStructure.md`
+
+既に存在するフォルダは作り直しません。生成したフォルダはダイアログとConsoleに一覧で出ます。
+
+---
+
+## AssemblyGenerator
+
+Assembly Definition（`.asmdef`）の生成と、既存asmdefへのGUID参照追加を行います。
+
+**入口**: メニューはありません。`PackageInitializer` などの他のEditor機能から呼ばれます。
+
+**注意点**:
+
+- 既に存在する `.asmdef` は上書きしません。
+- 参照の追加はGUID重複を避けます。同じ参照を二重に追加しません。
+
+---
+
+## SymphonyPackageLoader
+
+Frameworkが推奨するUnity公式パッケージの導入状況を確認し、不足分の導入をダイアログで確認します。
+
+**入口**: `Tools > SymphonyFrameWork > SymphonyPackageLoader`
+
+**対象パッケージの定義**: `<Frameworkルート>/Editor/PackageLoader/PackageList.txt`（1行1パッケージ）
+
+**注意点**:
+
+- Package Managerの初期化が終わっていない場合は何もしません。
+- 導入は利用者の確認を経てから実行されます。無断でインストールしません。
+
+---
+
+## SymphonyDebugHUD
+
+FPS、メモリ使用量、任意テキストをGame Viewへ重ねて表示します。
+
+**入口**: `Tools > SymphonyFrameWork > SymphonyDebugHUD > Show` / `Hide`
+
+HUD本体はRuntimeの機能です。このメニューはEditorからの表示・非表示の入口だけを提供します。
+
+---
+
+## ログのファイル出力
+
+`SymphonyDebugLogger` の出力をファイルへ書き出します。
+
+**入口**: 自動実行（`SymphonyEditorOrchestrator` が起動時に開始します）
+
+**出力先**: `<Frameworkルート>/Cache/Log.txt`
+
+Frameworkの実配置パスを解決してその直下へ書くため、UPM経由（`Library/PackageCache/`）でもAssets直置きでも同じ位置関係になります。
+
+**注意点**:
+
+- `Cache/` は生成物です。**版管理へ含めないでください。**
+- 書き込みは定期的にまとめて行われます。1行ごとにファイルを開きません。
+
+---
+
+## SymphonyMcpTools
+
+MCPや自動化スクリプトから、SymphonyのRuntime状態をJSON文字列で読み取るためのツール群です。
+
+**入口**: メニューはありません。外部ツールから `SymphonyFrameWork.Editor.Debugger.SymphonyMcpTools` の各メソッドを呼びます。
+
+Service Locator、Scene Loader、Save Dataなどの状態を取得できます。戻り値は必ず有効なJSON文字列です。Play Mode外や未初期化の場合も、その旨を含むJSONを返します。
+
+**注意点**:
+
+- 読み取り専用です。Runtimeの状態を変更しません。
+- 人が状態を確認する場合はSymphony Administratorを使ってください。
+
+---
+
+## アセット保護
+
+`SymphonyAssetProtector`（`AssetPostprocessor`）が、Framework配下のアセット移動を検知して差し戻します。誤ってFramework本体を動かし、利用側プロジェクトのGUID参照を壊すことを防ぎます。
+
+**入口**: 自動実行。強さは `Project Settings > SymphonyFrameWork` の `Asset Protection Mode`
+
+| モード | 挙動 |
+| --- | --- |
+| `Enabled`（既定） | 移動を常に差し戻す。1回だけダイアログで通知する |
+| `Warning` | ダイアログで、続行するか差し戻すかを選ばせる |
+| `Disabled` | 移動を通し、Consoleへ通常ログを出す |
+
+**注意点**:
+
+- 意図してFramework配下のファイルを動かす場合は、`Asset Protection Mode` を `Warning` または `Disabled` にしてから操作してください。
+- 保護の対象はFrameworkルート（`Packages/symphonyframework` または `Assets/SymphonyFrameWork`）とその配下です。
+
+---
+
+## Inspector属性
+
+利用側のフィールドへ付けて、Inspectorの表示を変える属性です。属性の定義はRuntime、描画はEditorにあります。
+
+| 属性 | 効果 |
+| --- | --- |
+| `[ReadOnly]` | Inspectorで編集できないようにする |
+| `[DisplayText]` | フィールドの上に説明テキストを表示する |
+| `[TagSelector]` | 文字列フィールドをタグのドロップダウンにする |
+| `[SceneNameSelector]` | 文字列フィールドをシーン名のドロップダウンにする |
+| `[SubclassSelector]` | `[SerializeReference]` フィールドで、派生型をドロップダウンから選べるようにする |
+
+`[SubclassSelector]` は `[SerializeReference]` と組み合わせて使います。単独では効果がありません。
+
+---
+
+## 設定アセットの自動生成
+
+`SymphonyConfigManager` が、Framework動作に必要な設定アセットの存在を保証します。
+
+**入口**: 自動実行（`SymphonyEditorOrchestrator` の初期化から呼ばれます）
+
+**対象**:
+
+| 種別 | アセット | 置き場 |
+| --- | --- | --- |
+| Runtime（`ScriptableObject`） | `SceneLoadConfig` / `AudioConfig` / `SaveDataConfig` | `Assets/Resources/SymphonyFrameWork/` |
+| Editor（`ScriptableSingleton`） | `AutoEnumGeneratorConfig` | `ProjectSettings/Packages/symphonyframework/` |
+| Editor（`ScriptableSingleton`） | `SymphonyUserSettingConfig` | `UserSettings/SymphonyFrameWork/` |
+
+**注意点**:
+
+- **Runtime用のConfigは `internal` です。** コードから型として参照できません。InspectorとProject Settingsから設定してください。
+- 生成された設定アセットを複製しないでください。Frameworkは決まった位置の1つだけを読みます。
+
+---
+
+## Editorの初期化
+
+`SymphonyEditorOrchestrator` が、Unity EditorのホストライフサイクルをFrameworkの初期化・終了フェーズへ変換します。各Editorモジュールはこれ経由で開始・終了します。
+
+詳細は[Architecture.md の「起動と終了」](./Architecture.md)を参照してください。
+
+**注意点**:
+
+- `AssetPostprocessor` は任意のタイミングで呼ばれるため、各PostProcessorは変更の種類を記録してOrchestratorへ通知するだけにしています。ファイル生成と `AssetDatabase.Refresh` はOrchestratorがまとめて1回だけ実行します。
+- Editor起動時に複数のモジュールがアセットを変更しても、`AssetDatabase.Refresh` は最終段階で必要な場合に1回だけ走ります。
+
+---
+
+## 関連ドキュメント
+
+- [README.md](../README.md) — 機能一覧、インストール、Runtime APIのクイックスタート
+- [Architecture.md](./Architecture.md) — アセンブリ構成、初期化順、公開型の関係
+- [Deprecations.md](./Deprecations.md) — 非推奨APIと削除予定
+- [CHANGELOG.md](../CHANGELOG.md) — 変更履歴

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -184,6 +184,8 @@ Build Settingsのシーン一覧、タグ、レイヤー、Audio Groupの変更�
 
 **変更の検知**: `TagsAndLayersPostProcessor`（`AssetPostprocessor`）がタグ・レイヤー設定ファイルの変更を、`EditorBuildSettings.sceneListChanged` がシーン一覧の変更を検知します。検知した変更は `SymphonyEditorOrchestrator` へ通知され、まとめて1回処理されます。
 
+**補助メニュー**: `Tools > SymphonyFrameWork > Debug > CreateResourcesFolder` は、生成先の `Resources` フォルダを手動で作り直すためのものです。通常は自動生成に任せてください。
+
 **注意点**:
 
 - **生成されたenumを手で編集しないでください。** 再生成で失われます。

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Coroutine、非同期処理、遅延Destroy、遅延Invoke、Tweenをポーズ�
 
 ## Editor・デバッグ支援
 
+各機能の入口、設定の保存先、注意点は[Editor機能](./Documentation~/EditorTools.md)にあります。
+
 - `Symphony Administrator`: Service Locator、Scene Loader、Save Data、Pauseの状態確認
 - `SymphonyDebugHUD`: FPS、メモリ使用量、任意テキストのGame View表示
 - `SymphonyDebugLogger`: 複数行ログとEditorでの`Cache/Log.txt`出力
@@ -320,6 +322,8 @@ Package Managerから[`Samples/Runtime`](./Samples/Runtime)の各サンプルを
 
 - [変更履歴](./CHANGELOG.md)
 - [パッケージ構成・クラス図](./Documentation~/Architecture.md)
+- [Editor機能](./Documentation~/EditorTools.md)
+- [非推奨APIと削除予定](./Documentation~/Deprecations.md)
 - [AGENTS.md（AIエージェント向けの導線と常時ルール）](./AGENTS.md)
   - [利用コードを書くときの注意事項](./Documentation~/AgentUsage.md)
   - [利用コードの検証手順](./Documentation~/AgentVerification.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Issue: #119

Issue #119（Packagerのバージョンログと差分インポート）の Round 1 です。**この Round はドキュメントだけを変更し、C# には一切触れていません。**

## 背景

以降の Round で Packager の挙動を変え、出力物を増やすにあたり、**書き足す先が存在しない**ことが分かりました。

- Editor機能の説明は README の `Editor・デバッグ支援` にある10行の箇条書きだけで、`AssetStoreToolsPackager`、`SymphonyPackageLoader`、`SymphonyAssetProtector`、`SymphonyMcpTools`、Project Settings の各設定項目は**1行も書かれていませんでした**
- 非推奨APIの正本は CHANGELOG でしたが、CHANGELOG は時系列の記録であり、**「今なお非推奨で、まだ消えていないもの」を一覧できません**

## 変更内容

### 追加

- `Documentation~/EditorTools.md` — Editor機能の正本。`Editor/` 配下の全モジュールについて、何をするものか、どこから開くか、設定の保存先、版管理へ含めるべきかを記載
- `Documentation~/Deprecations.md` — 非推奨APIと削除予定の正本

### 変更

- `Documentation~/AgentUsage.md` の「非推奨APIの期限と移行先は CHANGELOG.md を正本とします」を `Deprecations.md` を正本とする記述へ変更（正本が2つになることを避けるため）
- `AGENTS.md` の参照先表を新しい2文書へ更新
- `README.md` に導線を追加

## 分かったこと

現在 `[Obsolete]` は7件あり、**そのうち6件は非推奨化が CHANGELOG に記載されておらず、削除予定も決まっていません**（`SymphonyDebugLogger` の4件、`SymphonyTween` の2件）。`Deprecations.md` では削除予定を「未定」と明記し、判断が必要な項目が残っていること自体を可視化しています。

## 検証

- `uloop-compile`: エラー0件、警告0件
- EditMode テスト: 239件中239件成功（`Success=true` / `Failed=0` / `Skipped=0`）。同じ結果を2回確認
- `Deprecations.md` の7件が、実際に `[Obsolete]` が付いているメンバーと一致することを確認（`SymphonyDebugLogger` 4件 / `SymphonyTween` 2件 / `EditorSymphonyConstant` 1件）
- 追加・変更した全ファイルの相対リンクが解決することを確認
- C# の変更が0件であることを確認

未確認（人の操作が必要）: `EditorTools.md` に記載したメニューパスと Project Settings の場所が実際に一致するか。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
