### PR TITLE
[add]Asset Store Tools Packagerにバージョンログを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [3.3.0] - 2026-08-05
+Asset Store Tools Packager に、パッケージ単位のリビジョン記録を追加しました。**Runtime の公開APIとセーブデータ形式は変更していません。** 変更は Editor 専用ツールに閉じています。
+
+### Add
+
+- **パッケージ対象ディレクトリごとにリビジョン番号を記録するようにしました。** 出力した `.unitypackage` を別プロジェクトへ取り込むとき、どのパッケージが前回から変わったのかを判定する手段がありませんでした。出力日時は「出力した日時」であって「中身が変わった日時」ではないため、判断材料になりません。
+
+  記録するファイルは3種類です。
+
+  | ファイル | 置き場 | 意味 |
+  | --- | --- | --- |
+  | `PackageVersions.json` | `Asset Store Tools Path` 直下 | このプロジェクトでの各ディレクトリの現在リビジョン |
+  | `ExportedVersion.json` | 各ディレクトリ直下 | そのパッケージを出力した時点のリビジョン |
+  | `PackageManifest.json` | 出力先フォルダ | その回に出力したパッケージ名とリビジョンの一覧 |
+
+  `ExportedVersion.json` はパッケージへ同梱されるため、**インポート先では「今そこに入っているパッケージのリビジョン」**を表します。これと `PackageManifest.json` を突き合わせることで、次のバージョンで差分インポートを実現します。
+
+  `PackageVersions.json` と `ExportedVersion.json` は `Assets/` 配下にあります。**インポート先での比較に使うため、利用側のリポジトリで版管理してください。**
+
+- **`EditorSymphonyConstant` へ3つの定数を追加しました。** `ASSET_STORE_TOOLS_VERSION_LOG_FILE_NAME`、`ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME`、`ASSET_STORE_TOOLS_MANIFEST_FILE_NAME` です。既存の `ASSET_STORE_TOOLS_CONFIG_FILE_NAME` と同じく、利用側が `.gitignore` やビルドスクリプトから名前で参照できるようにするためです。
+
+### Change
+
+- **パッケージ対象フォルダ配下を変更すると `PackageVersions.json` が更新されます。** 変更の検知は `AssetPostprocessor` が行い、書き出しは `SymphonyEditorOrchestrator` がまとめて1回だけ実行します。
+
+  リビジョンは「実際には変わっていないのに増える」ことがあります。Unityが再インポートしただけでも加算されるためです。これは**不要なインポートが1回余分に起きる方向**の誤りであり、「変わったのに増えない」という逆方向の誤りは起きません。
+
+- **`AssetStoreToolsPackager.Export` が出力時に `ExportedVersion.json` と `PackageManifest.json` を書くようになりました。** シグネチャと戻り値、および出力パッケージの既存の中身は変わりません。パッケージへ `ExportedVersion.json` が1ファイル増えます。
+
+- **統合パッケージ（`Export Mode = Combine`）だけで出力した場合、`PackageManifest.json` を作りません。** 統合パッケージはディレクトリ単位で取り出せず、差分インポートの単位にならないためです。その場合はConsoleへ警告を出します。
+
 ## [3.2.1] - 2026-08-05
 Editor機能と非推奨APIのドキュメントを追加しました。**コードは変更していません。** 公開API、シリアライズ形式、挙動のいずれも 3.2.0 と同じです。
 

--- a/Core/Editor/EditorSymphonyConstant.cs
+++ b/Core/Editor/EditorSymphonyConstant.cs
@@ -52,6 +52,15 @@ namespace SymphonyFrameWork.Core
 
         /// <summary> パッケージ化設定ファイルの名前。対象フォルダ直下に置かれる。 </summary>
         public const string ASSET_STORE_TOOLS_CONFIG_FILE_NAME = "PackagerConfig.json";
+
+        /// <summary> ディレクトリごとの現在リビジョンを持つバージョンログの名前。対象フォルダ直下に置かれる。 </summary>
+        public const string ASSET_STORE_TOOLS_VERSION_LOG_FILE_NAME = "PackageVersions.json";
+
+        /// <summary> 出力時のリビジョンを記録するファイルの名前。各パッケージ対象ディレクトリ直下に置かれる。 </summary>
+        public const string ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME = "ExportedVersion.json";
+
+        /// <summary> 出力したパッケージ名とリビジョンの一覧の名前。出力先フォルダに置かれる。 </summary>
+        public const string ASSET_STORE_TOOLS_MANIFEST_FILE_NAME = "PackageManifest.json";
         #endregion
 
         /// <summary> 管理ウィンドウ用UI Toolkitアセットの基準パス。 </summary>

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -38,6 +38,8 @@ Editor機能はGUI操作を入口とするため、この文書にコード例�
 | `UserSettings/SymphonyFrameWork/SymphonyUserSettingConfig.asset` | アセット保護の強さ、Service Locatorのログ設定 | **含めない（開発者ごと）** |
 | `Assets/Resources/SymphonyFrameWork/*.asset` | `SceneLoadConfig` / `AudioConfig` / `SaveDataConfig` | 含める |
 | `<Asset Store Tools Path>/PackagerConfig.json` | Packagerの除外フォルダと強制包含拡張子 | 含める |
+| `<Asset Store Tools Path>/PackageVersions.json` | ディレクトリごとの現在リビジョン | 含める |
+| `<Asset Store Tools Path>/<ディレクトリ>/ExportedVersion.json` | そのパッケージを出力した時点のリビジョン | 含める |
 | `<Frameworkルート>/Cache/Log.txt` | `SymphonyDebugLogger`の出力 | **含めない（生成物）** |
 
 ---
@@ -156,7 +158,28 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 
 **出力先**: `<Exported Packages Path>/Export_AssetStoreToolsPackage_<日時>/`
 
+### バージョンログ
+
+どのパッケージが前回から変わったのかを判定するために、リビジョン番号を記録します。
+
+| ファイル | 置き場 | 意味 | 誰が書くか |
+| --- | --- | --- | --- |
+| `PackageVersions.json` | `Asset Store Tools Path` 直下 | **このプロジェクトでの**各ディレクトリの現在リビジョン | ディレクトリ配下の変更を検知して自動で加算 |
+| `ExportedVersion.json` | 各ディレクトリ直下 | **そのパッケージを出力した時点の**リビジョン | パッケージ出力時に生成し、パッケージへ同梱する |
+| `PackageManifest.json` | 出力先フォルダ | その回に出力したパッケージ名とリビジョンの一覧 | パッケージ出力時に生成する |
+
+2種類のログは意味が違います。`PackageVersions.json` は「編集の履歴」、`ExportedVersion.json` は「出荷時点のスナップショット」です。`ExportedVersion.json` はパッケージへ同梱されるため、**インポート先のプロジェクトでは「今そこに入っているパッケージのリビジョン」**を表します。これと `PackageManifest.json` を突き合わせれば、インポートが必要なパッケージだけを判別できます。
+
+**リビジョンの加算**: `AssetStoreToolsVersionPostProcessor`（`AssetPostprocessor`）が対象ディレクトリ配下の変更を検知し、`SymphonyEditorOrchestrator` へ通知します。実際の書き出しはOrchestratorがまとめて1回だけ行います。
+
 **注意点**:
+
+- **`PackageVersions.json` と `ExportedVersion.json` は版管理へ含めてください。** インポート先での比較に使います。
+- リビジョンは「実際には変わっていないのに増える」ことがあります。Unityが再インポートしただけでも加算されるためです。これは**不要なインポートが1回余分に起きる方向**の誤りで、「変わったのに増えない」逆方向の誤りは起きません。
+- **統合パッケージ（`Export Mode = Combine`）は差分インポートの対象になりません。** ディレクトリ単位で取り出せないためです。`Combine` だけで出力すると `PackageManifest.json` は作られず、Consoleへ警告が出ます。
+- リビジョンを手で編集する場合、負の値は0として扱われます。
+
+### 出力全般の注意点
 
 - 確認ウィンドウで「（対象アセットなし）」と表示されたフォルダは、出力時に警告になります。`Used Dependencies` を有効にしていて、そのフォルダのアセットがプロジェクト内で1つも使われていない場合に起きます。
 - `Used Dependencies` は `AssetDatabase.GetDependencies` で依存関係を追います。この依存関係グラフに載らないファイル（`.asmdef` など）は `Force Include Extensions` で補います。

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsExportedVersion.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsExportedVersion.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     パッケージが出力された時点のリビジョン。
+    ///     各パッケージ対象ディレクトリ直下のExportedVersion.jsonとして保存され、パッケージへ同梱される。
+    /// </summary>
+    /// <remarks>
+    ///     インポート先のプロジェクトでは、このファイルが「今そこに入っているパッケージのリビジョン」を表す。
+    ///     出力先のマニフェストと突き合わせることで、インポートが必要なパッケージを判定する。
+    /// </remarks>
+    internal sealed class AssetStoreToolsExportedVersion
+    {
+        /// <summary> パッケージ対象ディレクトリの名前。 </summary>
+        [JsonProperty("name")]
+        public string Name;
+
+        /// <summary> 出力した時点のリビジョン。 </summary>
+        [JsonProperty("version")]
+        public int Version;
+
+        /// <summary> 出力した日時。記録用で、比較には使わない。 </summary>
+        [JsonProperty("exportedAt")]
+        public string ExportedAt;
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsExportedVersion.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsExportedVersion.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef85fe123b66b8144a52d6f8f91991f3

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageManifest.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageManifest.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+
+using System.Collections.Generic;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     1回の出力で作成したパッケージ名とリビジョンの一覧。
+    ///     出力先フォルダのPackageManifest.jsonとして保存される。
+    /// </summary>
+    /// <remarks>
+    ///     個別出力したパッケージだけを記録する。統合パッケージはディレクトリ単位で取り出せず、
+    ///     差分インポートの単位にならないため含めない。
+    /// </remarks>
+    internal sealed class AssetStoreToolsPackageManifest
+    {
+        /// <summary> 出力した日時。記録用で、比較には使わない。 </summary>
+        [JsonProperty("exportedAt")]
+        public string ExportedAt;
+
+        /// <summary> 出力した個別パッケージの一覧。 </summary>
+        [JsonProperty("packages")]
+        public List<AssetStoreToolsPackageManifestEntry> Packages = new();
+    }
+
+    /// <summary> 出力した個別パッケージ1件分の記録。 </summary>
+    internal sealed class AssetStoreToolsPackageManifestEntry
+    {
+        /// <summary> パッケージ対象ディレクトリの名前。 </summary>
+        [JsonProperty("name")]
+        public string Name;
+
+        /// <summary> 出力した時点のリビジョン。 </summary>
+        [JsonProperty("version")]
+        public int Version;
+
+        /// <summary> 出力したパッケージのファイル名。 </summary>
+        [JsonProperty("fileName")]
+        public string FileName;
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageManifest.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageManifest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10be48d4eb94b6141a7be138377adf73

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagePlan.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagePlan.cs
@@ -40,6 +40,9 @@ namespace SymphonyFrameWork.Editor
         /// <summary> パッケージ名と表示に使うディレクトリ名。 </summary>
         public string Name;
 
+        /// <summary> 計画を組んだ時点のリビジョン。出力時バージョンとマニフェストへ記録する。 </summary>
+        public int Version;
+
         /// <summary> このディレクトリから出力されるアセットのパス一覧。 </summary>
         public IReadOnlyList<string> AssetPaths = new List<string>();
     }

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
@@ -133,16 +133,24 @@ namespace SymphonyFrameWork.Editor
                 ? GetProjectUsedDependencies(AssetStoreToolsPackagerData.AssetStoreToolsPath)
                 : null;
 
+            // 読み込めない場合もリビジョン0として出力は続行する。
+            // 差分インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
+            AssetStoreToolsVersionLog versionLog = AssetStoreToolsVersionLogStore.Load();
+
             List<AssetStoreToolsPackagePlanEntry> entries = new();
             foreach (string dir in directories)
             {
+                string name = Path.GetFileName(dir);
+                string[] assetPaths = usedAssetPaths != null
+                    ? CollectExportAssets(dir, usedAssetPaths, config.ForceIncludeExtensions)
+                    : CollectAllAssets(dir);
+
                 entries.Add(new AssetStoreToolsPackagePlanEntry
                 {
                     DirectoryPath = dir,
-                    Name = Path.GetFileName(dir),
-                    AssetPaths = usedAssetPaths != null
-                        ? CollectExportAssets(dir, usedAssetPaths, config.ForceIncludeExtensions)
-                        : CollectAllAssets(dir),
+                    Name = name,
+                    Version = versionLog?.GetVersion(name) ?? 0,
+                    AssetPaths = assetPaths,
                 });
             }
 
@@ -179,6 +187,11 @@ namespace SymphonyFrameWork.Editor
                 Directory.CreateDirectory(context.ExportFullPath);
             }
 
+            // 出力時バージョンを先に書き、AssetDatabaseへ載せてからパッケージ化する。
+            // Refreshを省くと新規ファイルがAssetDatabaseに載らず、Recurseでも明示指定でも出力されない。
+            WriteExportedVersions(plan);
+            AssetDatabase.Refresh();
+
             if ((plan.Mode & PackageModeEnum.Singles) != 0)
             {
                 ExportPackage(context, plan);
@@ -187,6 +200,19 @@ namespace SymphonyFrameWork.Editor
             if ((plan.Mode & PackageModeEnum.Combine) != 0)
             {
                 CreateCombinedPackage(context, plan);
+            }
+
+            // マニフェストは個別出力のときだけ書く。ZIPへ含めるためZIP化より前に書く。
+            if ((plan.Mode & PackageModeEnum.Singles) != 0)
+            {
+                WriteManifest(context, plan);
+            }
+            else if ((plan.Mode & PackageModeEnum.Combine) != 0)
+            {
+                Debug.LogWarning(
+                    $"[{nameof(AssetStoreToolsPackager)}]\n"
+                    + "統合パッケージだけの出力は差分インポートの対象になりません。"
+                    + "ディレクトリ単位で取り出せないためです。");
             }
 
             if (plan.CreateZip)
@@ -199,6 +225,81 @@ namespace SymphonyFrameWork.Editor
 
 
         private const string PACKAGE_NAME = "AssetStoreToolsPackage";
+
+        /// <summary>
+        ///     出力対象アセットへ出力時バージョンファイルのパスを加える。
+        /// </summary>
+        /// <remarks>
+        ///     「Used Dependencies」の経路では計画の一覧がそのままExportPackageの引数になるため、
+        ///     ここで加えないとバージョンファイルがパッケージへ含まれない。
+        ///     計画そのものへは加えない。加えると空のディレクトリを検出できなくなる。
+        /// </remarks>
+        /// <param name="assetPaths"> 収集済みの出力対象アセット。 </param>
+        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
+        /// <returns> パスの昇順で並んだ出力対象アセットのパス。 </returns>
+        private static string[] AppendExportedVersionPath(
+            IEnumerable<string> assetPaths,
+            string directoryPath)
+        {
+            string exportedVersionPath = BuildExportedVersionPath(directoryPath);
+
+            return assetPaths
+                .Append(exportedVersionPath)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        /// <summary> ディレクトリ直下の出力時バージョンファイルのパスを組み立てる。 </summary>
+        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
+        /// <returns> スラッシュ区切りのアセットパス。 </returns>
+        private static string BuildExportedVersionPath(string directoryPath)
+            => directoryPath.Replace("\\", "/").TrimEnd('/')
+               + "/" + EditorSymphonyConstant.ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME;
+
+        /// <summary>
+        ///     計画中の各ディレクトリへ出力時バージョンを書き出す。
+        /// </summary>
+        /// <remarks>
+        ///     書き込みに失敗しても出力は続行する。バージョンファイルの無いパッケージは
+        ///     インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
+        /// </remarks>
+        /// <param name="plan"> 出力する計画。 </param>
+        private static void WriteExportedVersions(AssetStoreToolsPackagePlan plan)
+        {
+            foreach (AssetStoreToolsPackagePlanEntry entry in plan.Entries)
+            {
+                AssetStoreToolsVersionLogStore.TryWriteExportedVersion(
+                    entry.DirectoryPath,
+                    entry.Name,
+                    entry.Version);
+            }
+        }
+
+        /// <summary>
+        ///     出力先フォルダへ、個別出力したパッケージ一覧のマニフェストを書き出す。
+        /// </summary>
+        /// <param name="context"> 出力先を保持するパッケージコンテキスト。 </param>
+        /// <param name="plan"> 出力した計画。 </param>
+        private static void WriteManifest(
+            in AssetStoreToolsPackageContext context,
+            AssetStoreToolsPackagePlan plan)
+        {
+            var manifest = new AssetStoreToolsPackageManifest
+            {
+                ExportedAt = AssetStoreToolsVersionLog.CreateTimestamp(),
+                Packages = plan.Entries
+                    .Select(entry => new AssetStoreToolsPackageManifestEntry
+                    {
+                        Name = entry.Name,
+                        Version = entry.Version,
+                        FileName = $"{entry.Name}.unitypackage",
+                    })
+                    .ToList(),
+            };
+
+            AssetStoreToolsVersionLogStore.TryWriteManifest(context.ExportFullPath, manifest);
+        }
 
         /// <summary>
         ///     個別のパッケージ生成。
@@ -224,7 +325,8 @@ namespace SymphonyFrameWork.Editor
                             continue;
                         }
 
-                        exportFiles = entry.AssetPaths.ToArray();
+                        // 出力時バージョンは計画に含めず、ここで加える。
+                        exportFiles = AppendExportedVersionPath(entry.AssetPaths, entry.DirectoryPath);
                         options = ExportPackageOptions.Default;
                     }
                     else
@@ -268,17 +370,19 @@ namespace SymphonyFrameWork.Editor
 
                 if (plan.UsedDependencies)
                 {
-                    exportFiles = plan.Entries
-                        .SelectMany(entry => entry.AssetPaths)
-                        .Distinct()
-                        .ToArray();
-                    options = ExportPackageOptions.Default;
-
-                    if (exportFiles.Length == 0)
+                    // 空判定は出力時バージョンを加える前に行う。加えた後では常に非空になる。
+                    if (plan.Entries.All(entry => entry.AssetPaths.Count == 0))
                     {
                         Debug.LogWarning("使用中アセットが存在しないため統合パッケージを作成しませんでした。");
                         return;
                     }
+
+                    exportFiles = plan.Entries
+                        .SelectMany(entry =>
+                            AppendExportedVersionPath(entry.AssetPaths, entry.DirectoryPath))
+                        .Distinct()
+                        .ToArray();
+                    options = ExportPackageOptions.Default;
                 }
                 else
                 {

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLog.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLog.cs
@@ -1,0 +1,163 @@
+﻿using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     パッケージ対象ディレクトリごとの現在リビジョン。
+    ///     対象フォルダ直下のPackageVersions.jsonとして保存される。
+    /// </summary>
+    /// <remarks>
+    ///     リビジョンは「このプロジェクトでの編集の履歴」を表す。
+    ///     パッケージへ同梱される出力時バージョンとは意味が異なる。
+    /// </remarks>
+    internal sealed class AssetStoreToolsVersionLog
+    {
+        /// <summary> ディレクトリごとのリビジョン。 </summary>
+        [JsonProperty("directories")]
+        public List<AssetStoreToolsVersionEntry> Directories = new();
+
+        /// <summary>
+        ///     指定したディレクトリ名をリビジョン1で登録した初期状態を生成する。
+        /// </summary>
+        /// <param name="directoryNames"> 登録するディレクトリ名。 </param>
+        /// <returns> 全ディレクトリをリビジョン1で持つバージョンログ。 </returns>
+        internal static AssetStoreToolsVersionLog CreateDefault(IEnumerable<string> directoryNames)
+        {
+            var log = new AssetStoreToolsVersionLog();
+
+            if (directoryNames == null)
+            {
+                return log;
+            }
+
+            string timestamp = CreateTimestamp();
+            foreach (string name in directoryNames)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                log.Directories.Add(new AssetStoreToolsVersionEntry
+                {
+                    Name = name.Trim(),
+                    Version = 1,
+                    UpdatedAt = timestamp,
+                });
+            }
+
+            return log;
+        }
+
+        /// <summary> 記録用のタイムスタンプを生成する。 </summary>
+        /// <returns> ラウンドトリップ可能な書式のUTC時刻。 </returns>
+        internal static string CreateTimestamp() => DateTime.UtcNow.ToString("o");
+
+        /// <summary>
+        ///     空要素や不正なリビジョンを取り除いた正規化済みのログを返す。元のインスタンスは変更しない。
+        /// </summary>
+        /// <returns> 名前の空要素を除き、負のリビジョンを0へ丸めたログ。 </returns>
+        internal AssetStoreToolsVersionLog Normalize() => new()
+        {
+            Directories = NormalizeEntries(Directories),
+        };
+
+        /// <summary>
+        ///     指定ディレクトリの現在リビジョンを取得する。
+        /// </summary>
+        /// <param name="name"> ディレクトリ名。 </param>
+        /// <returns> 登録済みのリビジョン。未登録の場合は0。 </returns>
+        internal int GetVersion(string name)
+        {
+            AssetStoreToolsVersionEntry entry = FindEntry(name);
+            return entry?.Version ?? 0;
+        }
+
+        /// <summary>
+        ///     指定ディレクトリのリビジョンを1つ進め、更新日時を記録する。
+        /// </summary>
+        /// <remarks> 未登録のディレクトリはリビジョン1で登録する。 </remarks>
+        /// <param name="name"> ディレクトリ名。 </param>
+        internal void IncrementVersion(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            AssetStoreToolsVersionEntry entry = FindEntry(name);
+
+            if (entry == null)
+            {
+                Directories.Add(new AssetStoreToolsVersionEntry
+                {
+                    Name = name.Trim(),
+                    Version = 1,
+                    UpdatedAt = CreateTimestamp(),
+                });
+                return;
+            }
+
+            entry.Version++;
+            entry.UpdatedAt = CreateTimestamp();
+        }
+
+        /// <summary> 名前で登録済みエントリを検索する。大文字小文字は区別しない。 </summary>
+        /// <param name="name"> ディレクトリ名。 </param>
+        /// <returns> 一致したエントリ。無い場合はnull。 </returns>
+        private AssetStoreToolsVersionEntry FindEntry(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name) || Directories == null)
+            {
+                return null;
+            }
+
+            string trimmedName = name.Trim();
+            return Directories.FirstOrDefault(entry =>
+                entry != null
+                && string.Equals(entry.Name, trimmedName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary> エントリから空要素を捨て、名前の空白を落として負のリビジョンを丸める。 </summary>
+        private static List<AssetStoreToolsVersionEntry> NormalizeEntries(
+            List<AssetStoreToolsVersionEntry> source)
+        {
+            if (source == null)
+            {
+                return new List<AssetStoreToolsVersionEntry>();
+            }
+
+            return source
+                .Where(entry => entry != null && !string.IsNullOrWhiteSpace(entry.Name))
+                .Select(entry => new AssetStoreToolsVersionEntry
+                {
+                    Name = entry.Name.Trim(),
+
+                    // 手で編集して負値になった場合は未登録と同じ扱いへ丸める。
+                    Version = entry.Version < 0 ? 0 : entry.Version,
+                    UpdatedAt = entry.UpdatedAt,
+                })
+                .ToList();
+        }
+    }
+
+    /// <summary> パッケージ対象ディレクトリ1件分のリビジョン。 </summary>
+    internal sealed class AssetStoreToolsVersionEntry
+    {
+        /// <summary> パッケージ対象ディレクトリの名前。 </summary>
+        [JsonProperty("name")]
+        public string Name;
+
+        /// <summary> 現在のリビジョン。 </summary>
+        [JsonProperty("version")]
+        public int Version;
+
+        /// <summary> 最後にリビジョンを進めた日時。記録用で、比較には使わない。 </summary>
+        [JsonProperty("updatedAt")]
+        public string UpdatedAt;
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLog.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 433ebf7245f7b274eb0bd038ca607a95

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLogStore.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLogStore.cs
@@ -1,0 +1,216 @@
+﻿using Newtonsoft.Json;
+
+using SymphonyFrameWork.Core;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     バージョンログ、出力時バージョン、出力マニフェストの読み書きを担う。
+    /// </summary>
+    internal static class AssetStoreToolsVersionLogStore
+    {
+        /// <summary>
+        ///     現在の対象フォルダ設定からバージョンログのパスを組み立てる。
+        /// </summary>
+        /// <returns> バージョンログのパス。対象フォルダが未設定の場合は空文字。 </returns>
+        internal static string GetVersionLogFilePath()
+        {
+            string root = AssetStoreToolsPackagerData.AssetStoreToolsPath;
+            if (string.IsNullOrEmpty(root))
+            {
+                return string.Empty;
+            }
+
+            return CombinePath(root, EditorSymphonyConstant.ASSET_STORE_TOOLS_VERSION_LOG_FILE_NAME);
+        }
+
+        /// <summary>
+        ///     バージョンログを読み込む。ファイルが存在しない場合は現在のディレクトリ一覧から生成する。
+        /// </summary>
+        /// <remarks>
+        ///     壊れたファイルを既定値へフォールバックさせない。全ディレクトリのリビジョンが巻き戻り、
+        ///     インポート先が「更新なし」と誤判定するため。
+        /// </remarks>
+        /// <returns> 正規化済みのバージョンログ。読み込みに失敗した場合はnull。 </returns>
+        internal static AssetStoreToolsVersionLog Load()
+        {
+            string logPath = GetVersionLogFilePath();
+            if (string.IsNullOrEmpty(logPath))
+            {
+                Debug.LogError($"{LOG_PREFIX}\nAssetStoreToolsフォルダのパスが設定されていません。");
+                return null;
+            }
+
+            if (!File.Exists(logPath))
+            {
+                return CreateVersionLogFile(logPath);
+            }
+
+            try
+            {
+                string json = File.ReadAllText(logPath);
+                var log = JsonConvert.DeserializeObject<AssetStoreToolsVersionLog>(json);
+
+                if (log == null)
+                {
+                    Debug.LogError($"{LOG_PREFIX}\nバージョンログの内容が空です: {logPath}");
+                    return null;
+                }
+
+                return log.Normalize();
+            }
+            catch (JsonException e)
+            {
+                Debug.LogError($"{LOG_PREFIX}\nバージョンログの解析に失敗しました: {logPath}\n{e.Message}");
+                return null;
+            }
+            catch (IOException e)
+            {
+                Debug.LogError($"{LOG_PREFIX}\nバージョンログの読み込みに失敗しました: {logPath}\n{e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     バージョンログをJSONへ保存する。
+        /// </summary>
+        /// <param name="log"> 保存するバージョンログ。正規化してから書き出す。 </param>
+        /// <returns> 書き込みに成功した場合はtrue。 </returns>
+        internal static bool Save(AssetStoreToolsVersionLog log)
+        {
+            if (log == null)
+            {
+                return false;
+            }
+
+            string logPath = GetVersionLogFilePath();
+            if (string.IsNullOrEmpty(logPath))
+            {
+                Debug.LogError($"{LOG_PREFIX}\nAssetStoreToolsフォルダのパスが設定されていません。");
+                return false;
+            }
+
+            return TryWriteJson(logPath, log.Normalize(), "バージョンログ");
+        }
+
+        /// <summary>
+        ///     パッケージ対象ディレクトリへ出力時バージョンを書き出す。
+        /// </summary>
+        /// <param name="directoryPath"> 書き出し先のディレクトリパス。 </param>
+        /// <param name="name"> パッケージ対象ディレクトリの名前。 </param>
+        /// <param name="version"> 出力する時点のリビジョン。 </param>
+        /// <returns> 書き込みに成功した場合はtrue。 </returns>
+        internal static bool TryWriteExportedVersion(string directoryPath, string name, int version)
+        {
+            if (string.IsNullOrEmpty(directoryPath))
+            {
+                return false;
+            }
+
+            var exportedVersion = new AssetStoreToolsExportedVersion
+            {
+                Name = name,
+                Version = version,
+                ExportedAt = AssetStoreToolsVersionLog.CreateTimestamp(),
+            };
+
+            string path = CombinePath(
+                directoryPath,
+                EditorSymphonyConstant.ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME);
+
+            return TryWriteJson(path, exportedVersion, "出力時バージョン");
+        }
+
+        /// <summary>
+        ///     出力先フォルダへパッケージ一覧のマニフェストを書き出す。
+        /// </summary>
+        /// <param name="exportFullPath"> 出力先フォルダの絶対パス。 </param>
+        /// <param name="manifest"> 書き出すマニフェスト。 </param>
+        /// <returns> 書き込みに成功した場合はtrue。 </returns>
+        internal static bool TryWriteManifest(
+            string exportFullPath,
+            AssetStoreToolsPackageManifest manifest)
+        {
+            if (string.IsNullOrEmpty(exportFullPath) || manifest == null)
+            {
+                return false;
+            }
+
+            string path = Path.Combine(
+                exportFullPath,
+                EditorSymphonyConstant.ASSET_STORE_TOOLS_MANIFEST_FILE_NAME);
+
+            return TryWriteJson(path, manifest, "パッケージマニフェスト");
+        }
+
+        private const string LOG_PREFIX = "[" + nameof(AssetStoreToolsVersionLogStore) + "]";
+
+        /// <summary>
+        ///     バージョンログを新規生成する。現在存在するディレクトリをリビジョン1で登録する。
+        /// </summary>
+        /// <param name="logPath"> 生成するバージョンログのパス。 </param>
+        /// <returns> 生成した正規化済みのバージョンログ。生成に失敗した場合はnull。 </returns>
+        private static AssetStoreToolsVersionLog CreateVersionLogFile(string logPath)
+        {
+            string root = AssetStoreToolsPackagerData.AssetStoreToolsPath;
+            if (!Directory.Exists(root))
+            {
+                Debug.LogError($"{LOG_PREFIX}\nAssetStoreToolsフォルダが存在しません: {root}");
+                return null;
+            }
+
+            IEnumerable<string> directoryNames = Directory
+                .GetDirectories(root)
+                .Select(Path.GetFileName);
+
+            AssetStoreToolsVersionLog log = AssetStoreToolsVersionLog.CreateDefault(directoryNames);
+
+            if (!TryWriteJson(logPath, log.Normalize(), "バージョンログ"))
+            {
+                return null;
+            }
+
+            Debug.Log($"{LOG_PREFIX}\nバージョンログを生成しました: {logPath}");
+            return log.Normalize();
+        }
+
+        /// <summary>
+        ///     オブジェクトを整形済みJSONとして書き出す。
+        /// </summary>
+        /// <param name="path"> 書き出し先のパス。 </param>
+        /// <param name="value"> 書き出す内容。 </param>
+        /// <param name="displayName"> 失敗ログへ出す対象の呼び名。 </param>
+        /// <returns> 書き込みに成功した場合はtrue。 </returns>
+        private static bool TryWriteJson(string path, object value, string displayName)
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                Debug.LogError($"{LOG_PREFIX}\n{displayName}の書き出し先が存在しません: {directory}");
+                return false;
+            }
+
+            try
+            {
+                string json = JsonConvert.SerializeObject(value, Formatting.Indented);
+                File.WriteAllText(path, json);
+                return true;
+            }
+            catch (IOException e)
+            {
+                Debug.LogError($"{LOG_PREFIX}\n{displayName}の保存に失敗しました: {path}\n{e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary> ディレクトリとファイル名をスラッシュ区切りで連結する。 </summary>
+        private static string CombinePath(string directory, string fileName)
+            => directory.Replace("\\", "/").TrimEnd('/') + "/" + fileName;
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLogStore.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionLogStore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0cc1840f5bcdb3141821ab0bff374288

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPathResolver.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPathResolver.cs
@@ -1,0 +1,100 @@
+﻿using SymphonyFrameWork.Core;
+
+using System;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     変更されたアセットのパスから、リビジョンを加算する対象ディレクトリ名を解決する。
+    /// </summary>
+    /// <remarks>
+    ///     Unity APIへ触れない純粋なロジックとして保つ。呼び出し側はこの判定結果だけを見る。
+    /// </remarks>
+    internal static class AssetStoreToolsVersionPathResolver
+    {
+        /// <summary>
+        ///     アセットパスがどのパッケージ対象ディレクトリに属するかを解決する。
+        /// </summary>
+        /// <remarks>
+        ///     対象フォルダ直下のファイル（設定ファイルやバージョンログ自身）と、
+        ///     ディレクトリ自身のパスは対象外にする。
+        ///     各ディレクトリ内の出力時バージョンファイルも対象外にする。
+        ///     これを加算対象にすると、パッケージ出力で書いたファイルが再び加算を呼び、
+        ///     リビジョンが際限なく増える。
+        /// </remarks>
+        /// <param name="assetPath"> 変更されたアセットのパス。 </param>
+        /// <param name="rootPath"> パッケージ対象フォルダのルートパス。 </param>
+        /// <param name="directoryName"> 解決したディレクトリ名。解決できない場合はnull。 </param>
+        /// <returns> リビジョンの加算対象であればtrue。 </returns>
+        internal static bool TryResolveDirectoryName(
+            string assetPath,
+            string rootPath,
+            out string directoryName)
+        {
+            directoryName = null;
+
+            if (string.IsNullOrEmpty(assetPath) || string.IsNullOrEmpty(rootPath))
+            {
+                return false;
+            }
+
+            string normalizedAssetPath = assetPath.Replace('\\', '/');
+            string normalizedRootPath = rootPath.Replace('\\', '/').TrimEnd('/');
+            if (normalizedRootPath.Length == 0)
+            {
+                return false;
+            }
+
+            string rootPrefix = normalizedRootPath + "/";
+            if (!normalizedAssetPath.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            string relativePath = normalizedAssetPath.Substring(rootPrefix.Length);
+
+            // 区切りが無い場合は対象フォルダ直下のファイルかディレクトリ自身であり、
+            // どのパッケージにも属さない。
+            int separatorIndex = relativePath.IndexOf('/');
+            if (separatorIndex <= 0)
+            {
+                return false;
+            }
+
+            string name = relativePath.Substring(0, separatorIndex);
+            string remainingPath = relativePath.Substring(separatorIndex + 1);
+
+            if (IsExportedVersionFile(remainingPath))
+            {
+                return false;
+            }
+
+            directoryName = name;
+            return true;
+        }
+
+        /// <summary> Unityが生成するメタデータファイルの拡張子。 </summary>
+        private const string META_EXTENSION = ".meta";
+
+        /// <summary>
+        ///     ディレクトリからの相対パスが出力時バージョンファイルを指すか判定する。
+        /// </summary>
+        /// <param name="remainingPath"> ディレクトリ名を除いた相対パス。 </param>
+        /// <returns> バージョンファイルまたはその.metaであればtrue。 </returns>
+        private static bool IsExportedVersionFile(string remainingPath)
+        {
+            string fileName = remainingPath;
+
+            // .metaはコールバックの引数に含まれないが、将来含まれても除外が崩れないようにする。
+            if (fileName.EndsWith(META_EXTENSION, StringComparison.OrdinalIgnoreCase))
+            {
+                fileName = fileName.Substring(0, fileName.Length - META_EXTENSION.Length);
+            }
+
+            return string.Equals(
+                fileName,
+                EditorSymphonyConstant.ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME,
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPathResolver.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPathResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 712ea0701618db04ebc9308141042d15

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPostProcessor.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPostProcessor.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+
+using UnityEditor;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     パッケージ対象ディレクトリの変更を検知し、リビジョンの加算を処理待ちへ積む。
+    /// </summary>
+    /// <remarks>
+    ///     AssetPostprocessorは任意のタイミングで再入するため、この型はファイル書き込み、
+    ///     AssetDatabase.Refresh、購読を所有しない。変更を記録してSymphonyEditorOrchestratorへ
+    ///     通知し、実際の書き出しはOrchestratorがcoalesceして1回だけ行う。
+    /// </remarks>
+    internal sealed class AssetStoreToolsVersionPostProcessor : AssetPostprocessor
+    {
+        /// <summary> host callbackによる変更が処理待ちになったときに通知する。 </summary>
+        internal static event Action OnHostChangesPending;
+
+        /// <summary> 処理待ちのディレクトリ名を破棄する。 </summary>
+        internal static void Initialize()
+        {
+            _pendingDirectoryNames.Clear();
+        }
+
+        /// <summary> 処理待ちのディレクトリ名を破棄する。 </summary>
+        internal static void Shutdown()
+        {
+            _pendingDirectoryNames.Clear();
+        }
+
+        /// <summary>
+        ///     coalesceした変更ぶんのリビジョンを進め、バージョンログを1回だけ書き出す。
+        /// </summary>
+        /// <returns> バージョンログを書き出し、AssetDatabaseの更新が必要な場合はtrue。 </returns>
+        internal static bool ProcessPendingChanges()
+        {
+            if (_pendingDirectoryNames.Count == 0)
+            {
+                return false;
+            }
+
+            // 先に消費する。書き出しに失敗しても同じ変更で再入し続けないようにする。
+            string[] directoryNames = new string[_pendingDirectoryNames.Count];
+            _pendingDirectoryNames.CopyTo(directoryNames);
+            _pendingDirectoryNames.Clear();
+
+            AssetStoreToolsVersionLog log = AssetStoreToolsVersionLogStore.Load();
+
+            // 壊れたバージョンログを読み込めなかった場合は加算しない。
+            // 巻き戻したリビジョンで上書きすると、インポート先が更新を見落とす。
+            if (log == null)
+            {
+                return false;
+            }
+
+            foreach (string directoryName in directoryNames)
+            {
+                log.IncrementVersion(directoryName);
+            }
+
+            return AssetStoreToolsVersionLogStore.Save(log);
+        }
+
+        /// <summary> 加算対象として記録済みのディレクトリ名。 </summary>
+        private static readonly HashSet<string> _pendingDirectoryNames =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary> パッケージ対象ディレクトリ配下の変更を処理待ちとして記録する。 </summary>
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            string rootPath = AssetStoreToolsPackagerData.AssetStoreToolsPath;
+            if (string.IsNullOrEmpty(rootPath))
+            {
+                return;
+            }
+
+            bool hasPendingChange = false;
+            hasPendingChange |= CollectDirectoryNames(importedAssets, rootPath);
+            hasPendingChange |= CollectDirectoryNames(deletedAssets, rootPath);
+            hasPendingChange |= CollectDirectoryNames(movedAssets, rootPath);
+            hasPendingChange |= CollectDirectoryNames(movedFromAssetPaths, rootPath);
+
+            if (hasPendingChange)
+            {
+                OnHostChangesPending?.Invoke();
+            }
+        }
+
+        /// <summary>
+        ///     アセットパスから加算対象のディレクトリ名を集めて処理待ちへ積む。
+        /// </summary>
+        /// <param name="assetPaths"> 変更されたアセットのパス。 </param>
+        /// <param name="rootPath"> パッケージ対象フォルダのルートパス。 </param>
+        /// <returns> 1件でも積んだ場合はtrue。 </returns>
+        private static bool CollectDirectoryNames(string[] assetPaths, string rootPath)
+        {
+            if (assetPaths == null)
+            {
+                return false;
+            }
+
+            bool hasPendingChange = false;
+            foreach (string assetPath in assetPaths)
+            {
+                if (AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                        assetPath,
+                        rootPath,
+                        out string directoryName))
+                {
+                    hasPendingChange |= _pendingDirectoryNames.Add(directoryName);
+                }
+            }
+
+            return hasPendingChange;
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPostProcessor.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsVersionPostProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25805e46663d6d14ba0fed248d2ab712

--- a/Editor/Orchestrator/Internal/SymphonyEditorOrchestrator.cs
+++ b/Editor/Orchestrator/Internal/SymphonyEditorOrchestrator.cs
@@ -40,6 +40,8 @@ namespace SymphonyFrameWork.Editor
             SymphonyAssetProtector.OnHostChangesPending += HostChangesPendingHandler;
             TagsAndLayersPostProcessor.OnHostChangesPending -= HostChangesPendingHandler;
             TagsAndLayersPostProcessor.OnHostChangesPending += HostChangesPendingHandler;
+            AssetStoreToolsVersionPostProcessor.OnHostChangesPending -= HostChangesPendingHandler;
+            AssetStoreToolsVersionPostProcessor.OnHostChangesPending += HostChangesPendingHandler;
         }
 
         /// <summary> Unity Editorのhost callbackとAssetPostprocessor通知を解除する。 </summary>
@@ -50,6 +52,7 @@ namespace SymphonyFrameWork.Editor
             EditorApplication.playModeStateChanged -= PlayModeStateChangedHandler;
             SymphonyAssetProtector.OnHostChangesPending -= HostChangesPendingHandler;
             TagsAndLayersPostProcessor.OnHostChangesPending -= HostChangesPendingHandler;
+            AssetStoreToolsVersionPostProcessor.OnHostChangesPending -= HostChangesPendingHandler;
         }
 
         /// <summary> assembly reload前にEditorモジュールを終了する。 </summary>
@@ -119,6 +122,12 @@ namespace SymphonyFrameWork.Editor
                 initializingModuleName = nameof(AutoEnumGenerator);
                 AutoEnumGenerator.Initialize();
                 RecordInitializedModule(nameof(AutoEnumGenerator), AutoEnumGenerator.Shutdown);
+
+                initializingModuleName = nameof(AssetStoreToolsVersionPostProcessor);
+                AssetStoreToolsVersionPostProcessor.Initialize();
+                RecordInitializedModule(
+                    nameof(AssetStoreToolsVersionPostProcessor),
+                    AssetStoreToolsVersionPostProcessor.Shutdown);
 
                 initializingModuleName = nameof(SymphonyDebugLogFileWriter);
                 SymphonyDebugLogFileWriter.Initialize();
@@ -198,6 +207,8 @@ namespace SymphonyFrameWork.Editor
             {
                 TagsAndLayersPostProcessor.ProcessPendingChanges();
                 _requiresAssetDatabaseRefresh |= AutoEnumGenerator.ConsumeAssetChanges();
+                _requiresAssetDatabaseRefresh |=
+                    AssetStoreToolsVersionPostProcessor.ProcessPendingChanges();
                 SymphonyAssetProtector.ProcessPendingChanges();
                 RefreshAssetDatabaseIfRequired();
                 SymphonyAssetProtector.ProcessPendingChanges();

--- a/Tests/Editor/AssetStoreToolsVersionLogTests.cs
+++ b/Tests/Editor/AssetStoreToolsVersionLogTests.cs
@@ -1,0 +1,222 @@
+﻿using NUnit.Framework;
+
+using SymphonyFrameWork.Editor;
+
+using System.Collections.Generic;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary>
+    ///     バージョンログのリビジョン操作と、変更パスからのディレクトリ名解決を検証する。
+    /// </summary>
+    public sealed class AssetStoreToolsVersionLogTests
+    {
+        /// <summary> ディレクトリ配下のアセットからディレクトリ名を解決する。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_AssetUnderDirectory_ReturnsDirectoryName()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/Demigiant/DOTween/DOTween.dll",
+                ROOT_PATH,
+                out string directoryName);
+
+            Assert.That(result, Is.True);
+            Assert.That(directoryName, Is.EqualTo("Demigiant"));
+        }
+
+        /// <summary> 対象フォルダ直下のファイルはどのパッケージにも属さない。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_FileAtRoot_ReturnsFalse()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/PackagerConfig.json",
+                ROOT_PATH,
+                out string directoryName);
+
+            Assert.That(result, Is.False);
+            Assert.That(directoryName, Is.Null);
+        }
+
+        /// <summary> ディレクトリ自身のパスでは加算しない。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_DirectoryItself_ReturnsFalse()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/Demigiant",
+                ROOT_PATH,
+                out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary>
+        ///     出力時バージョンファイル自身では加算しない。
+        ///     加算するとパッケージ出力が次の加算を呼び、リビジョンが際限なく増える。
+        /// </summary>
+        [Test]
+        public void TryResolveDirectoryName_ExportedVersionFile_ReturnsFalse()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/Demigiant/ExportedVersion.json",
+                ROOT_PATH,
+                out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary> 出力時バージョンファイルの.metaでも加算しない。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_ExportedVersionMetaFile_ReturnsFalse()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/Demigiant/ExportedVersion.json.meta",
+                ROOT_PATH,
+                out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary> 対象フォルダの外は解決しない。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_OutsideRoot_ReturnsFalse()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/Scripts/Foo.cs",
+                ROOT_PATH,
+                out _);
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary> Windowsのパス区切りでも解決する。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_BackslashPath_ReturnsDirectoryName()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                @"Assets\AssetStoreTools\Demigiant\Foo.cs",
+                ROOT_PATH,
+                out string directoryName);
+
+            Assert.That(result, Is.True);
+            Assert.That(directoryName, Is.EqualTo("Demigiant"));
+        }
+
+        /// <summary> ルートパスの末尾スラッシュを許容する。 </summary>
+        [Test]
+        public void TryResolveDirectoryName_RootWithTrailingSlash_ReturnsDirectoryName()
+        {
+            bool result = AssetStoreToolsVersionPathResolver.TryResolveDirectoryName(
+                "Assets/AssetStoreTools/Demigiant/Foo.cs",
+                "Assets/AssetStoreTools/",
+                out string directoryName);
+
+            Assert.That(result, Is.True);
+            Assert.That(directoryName, Is.EqualTo("Demigiant"));
+        }
+
+        /// <summary> 未登録のディレクトリのリビジョンは0として扱う。 </summary>
+        [Test]
+        public void GetVersion_UnknownName_ReturnsZero()
+        {
+            var log = new AssetStoreToolsVersionLog();
+
+            Assert.That(log.GetVersion("Foo"), Is.Zero);
+        }
+
+        /// <summary> 未登録のディレクトリを加算するとリビジョン1で登録される。 </summary>
+        [Test]
+        public void IncrementVersion_UnknownName_BecomesOne()
+        {
+            var log = new AssetStoreToolsVersionLog();
+
+            log.IncrementVersion("Foo");
+
+            Assert.That(log.GetVersion("Foo"), Is.EqualTo(1));
+        }
+
+        /// <summary> 登録済みのリビジョンは1つだけ進む。 </summary>
+        [Test]
+        public void IncrementVersion_KnownName_AddsOne()
+        {
+            AssetStoreToolsVersionLog log = CreateLog("Foo", 3);
+
+            log.IncrementVersion("Foo");
+
+            Assert.That(log.GetVersion("Foo"), Is.EqualTo(4));
+        }
+
+        /// <summary> 加算すると更新日時が書き換わる。 </summary>
+        [Test]
+        public void IncrementVersion_UpdatesTimestamp()
+        {
+            AssetStoreToolsVersionLog log = CreateLog("Foo", 1);
+
+            // 絶対時刻ではなく、加算前の値からの変化で判定する。
+            string beforeTimestamp = log.Directories[0].UpdatedAt;
+            log.IncrementVersion("Foo");
+
+            Assert.That(log.Directories[0].UpdatedAt, Is.Not.EqualTo(beforeTimestamp));
+        }
+
+        /// <summary> フィールドが欠落したJSONを読んでも空一覧として扱う。 </summary>
+        [Test]
+        public void Normalize_NullEntries_BecomesEmptyList()
+        {
+            var log = new AssetStoreToolsVersionLog { Directories = null };
+
+            AssetStoreToolsVersionLog normalized = log.Normalize();
+
+            Assert.That(normalized.Directories, Is.Empty);
+        }
+
+        /// <summary> 名前が空白のみのエントリは捨てる。 </summary>
+        [Test]
+        public void Normalize_EntryWithEmptyName_IsRemoved()
+        {
+            var log = new AssetStoreToolsVersionLog
+            {
+                Directories = new List<AssetStoreToolsVersionEntry>
+                {
+                    new() { Name = "Foo", Version = 1 },
+                    new() { Name = "  ", Version = 2 },
+                },
+            };
+
+            AssetStoreToolsVersionLog normalized = log.Normalize();
+
+            Assert.That(normalized.Directories.Count, Is.EqualTo(1));
+            Assert.That(normalized.Directories[0].Name, Is.EqualTo("Foo"));
+        }
+
+        /// <summary> 手で編集して負値になったリビジョンは0へ丸める。 </summary>
+        [Test]
+        public void Normalize_NegativeVersion_BecomesZero()
+        {
+            AssetStoreToolsVersionLog log = CreateLog("Foo", -5);
+
+            AssetStoreToolsVersionLog normalized = log.Normalize();
+
+            Assert.That(normalized.GetVersion("Foo"), Is.Zero);
+        }
+
+        /// <summary> テストで使うパッケージ対象フォルダのルートパス。 </summary>
+        private const string ROOT_PATH = "Assets/AssetStoreTools";
+
+        /// <summary> 1件だけ登録した状態のバージョンログを生成する。 </summary>
+        /// <param name="name"> 登録するディレクトリ名。 </param>
+        /// <param name="version"> 登録するリビジョン。 </param>
+        /// <returns> 指定した1件を持つバージョンログ。 </returns>
+        private static AssetStoreToolsVersionLog CreateLog(string name, int version) => new()
+        {
+            Directories = new List<AssetStoreToolsVersionEntry>
+            {
+                new()
+                {
+                    Name = name,
+                    Version = version,
+                    UpdatedAt = "2000-01-01T00:00:00.0000000Z",
+                },
+            },
+        };
+    }
+}

--- a/Tests/Editor/AssetStoreToolsVersionLogTests.cs.meta
+++ b/Tests/Editor/AssetStoreToolsVersionLogTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0bb4055168ac32f44a4ddf1e012b7afc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Issue: #119

Issue #119 の Round 2 です。差分インポートの土台となる**リビジョン記録**を追加します。UI（2タブ化・Import タブ）は Round 3 で扱います。

## 仕組み

記録するファイルは3種類で、**2種類のログを分けるのが設計の中心**です。

| ファイル | 置き場 | 意味 | 誰が書くか |
| --- | --- | --- | --- |
| `PackageVersions.json` | AST 直下 | このプロジェクトでの現在リビジョン | `AssetPostprocessor` が変更を検知して加算 |
| `ExportedVersion.json` | 各ディレクトリ直下 | **出力した時点の**リビジョン。パッケージへ同梱 | 出力時に生成 |
| `PackageManifest.json` | 出力先フォルダ | その回の出力一覧 | 出力時に生成 |

`ExportedVersion.json` はパッケージに入るため、インポート先では「今そこに入っているパッケージのリビジョン」を表します。これと `PackageManifest.json` を突き合わせれば差分が判定できます。

## 設計上の要点

- **`AssetPostprocessor` はファイルを書きません。** 変更を記録して `SymphonyEditorOrchestrator` へ通知するだけで、書き出しと `AssetDatabase.Refresh` は Orchestrator が coalesce して1回だけ実行します（DesignPhilosophy の規約）。
- **自己ループしません。** ルートログは AST 直下にあるためパス解決で弾かれ、`ExportedVersion.json` はファイル名で明示除外します。回帰テストを2件置いています。
- **リビジョンはハッシュではなく整数です。** 限界は「変わっていないのに増える」ことで、これは*不要なインポートが1回余分に起きる*方向の誤りです。「変わったのに増えない」逆方向の誤りは起きません。

## 設計書からの変更

設計書では出力時バージョンのパスを**計画（`AssetPaths`）へ含める**としていましたが、実装時に**既存の「使用中アセットなし」検出が壊れる**ことが分かりました（一覧が常に非空になる）。計画へは含めず、`ExportPackage` へ渡す直前に加える形へ変更しています。確認ウィンドウに `ExportedVersion.json` は表示されませんが、これは枠組みが生成する管理ファイルであり、表示しないほうが妥当と判断しました。

## 検証

- `uloop-compile`: エラー0、パッケージ内の警告0
- EditMode テスト: **254件中254件成功**（`Success=true` / `Failed=0` / `Skipped=0`）。連続2回で確認。うち15件が新規
- **実際の Editor 上で動作を確認**（`AssetStoreTools` は gitignore 済みのため安全に実施）:
  - ディレクトリ配下へファイル追加 → `PackageVersions.json` が生成され、該当ディレクトリだけリビジョンが加算された（`TestPackage=2` / `Demigiant=1`）
  - 変更なしで2回リフレッシュ → 加算されない
  - `Singles` 出力 → `ExportedVersion.json`（version=2）と `PackageManifest.json` が生成され、**ルートログは加算されなかった**（自己ループしない）
  - 出力した `.unitypackage` を展開し、`ExportedVersion.json` が含まれることを確認
  - `Used Dependencies` 有効の経路でも同梱されることを確認
  - `Combine` のみ → マニフェストが作られず、警告が出ることを確認
- Play Mode 開始・終了を2往復 → 新しいエラーなし
- 新規 `.cs` 7件すべてに `.meta` が生成され、UTF-8 BOM 付きであることを確認
- Runtime/Core からの `UnityEditor` 参照なし、テスト asmdef の `UNITY_INCLUDE_TESTS` あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)
