### PR TITLE
[update]PackageModeEnum.Combineを非推奨にした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [3.4.0] - 2026-08-05
+Asset Store Tools Packager の統合パッケージ出力（`Combine`）を非推奨にしました。**削除はしていません。** 既存の指定はこれまでどおり動作します。
+
+### Deprecated
+
+- **`AssetStoreToolsPackager.PackageModeEnum.Combine` を非推奨にしました。** 統合パッケージは全ディレクトリを1つの `.unitypackage` へまとめるため、**ディレクトリ単位で取り出せず、差分インポートの単位になりません。**
+
+  3.3.0 で追加したバージョンログは、パッケージ単位のリビジョンを比較して「更新されたものだけを取り込む」ためのものです。`Combine` で出力したパッケージはこの比較に載せられないため、3.3.0 の時点で `Combine` だけの出力では `PackageManifest.json` を作っていません。実態として差分インポートの対象外である状態を、型の上でも明示しました。
+
+  **移行方法**: `Export Mode` を `Singles` にしてください。個別出力したパッケージは `PackageManifest.json` へ記録され、差分インポートの対象になります。コードから `AssetStoreToolsPackager.Export` を呼んでいる場合は、第2引数を `PackageModeEnum.Singles` にしてください。
+
+  **次のメジャー更新で `PackageModeEnum` ごと削除します。** `Combine` を除くと `Singles` しか残らず、enum と `Export` の `mode` 引数が意味を失うためです。旧シグネチャは型として成立しなくなるため `[Obsolete]` のシムを残せません。削除時に一緒に変わる箇所は [Deprecations.md](./Documentation~/Deprecations.md) に記録しています。
+
+### Change
+
+- **Packager ウィンドウで `Combine` を選ぶと、廃止予定である旨を表示するようにしました。** 選択自体は禁止していません。既存の運用を突然壊さず、移行期間を設けるためです。
+
+- `Combine` だけで出力したときのConsole警告に、廃止予定である旨と移行先を追記しました。
+
 ## [3.3.0] - 2026-08-05
 Asset Store Tools Packager に、パッケージ単位のリビジョン記録を追加しました。**Runtime の公開APIとセーブデータ形式は変更していません。** 変更は Editor 専用ツールに閉じています。
 

--- a/Documentation~/Deprecations.md
+++ b/Documentation~/Deprecations.md
@@ -24,6 +24,24 @@ CHANGELOGだけでは、非推奨化した版まで遡らないと一覧でき�
 | `SymphonyTween.TweeningLerp<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | `Task` を返す旧型式。移行先は `Awaitable` を返す |
 | `SymphonyTween.TweeningCurve<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | 同上 |
 | `EditorSymphonyConstant.ASSET_STORE_TOOLS_IGNORE_FILE` | `Core/Editor/EditorSymphonyConstant.cs` | `EditorSymphonyConstant.ASSET_STORE_TOOLS_CONFIG_FILE_NAME` | 3.1.0 | 次のメジャー更新 | 削除時は `AssetStoreToolsPackagerConfigStore` の `ignore.txt` 移行処理（`IGNORE_FILE_NAME`、`ReadIgnoreFile`、`CreateConfigFile` の移行分岐）も一緒に削除する |
+| `AssetStoreToolsPackager.PackageModeEnum.Combine` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `PackageModeEnum.Singles` | 3.4.0 | 次のメジャー更新 | **削除時は `PackageModeEnum` ごと削除する。** 下記「Combineの削除手順」を参照 |
+
+### Combineの削除手順
+
+`Combine` を削除すると `PackageModeEnum` に `Singles` と `Nothing` しか残らず、enum 自体が意味を失います。**次のメジャー更新で enum ごと削除します。** そのとき一緒に直す箇所を記録しておきます。
+
+| 対象 | 変更内容 |
+| --- | --- |
+| `AssetStoreToolsPackager.PackageModeEnum` | 削除する |
+| `AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` | `Export(string[], bool, bool)` へ変更する |
+| `AssetStoreToolsPackager.CreateCombinedPackage` | 削除する |
+| `AssetStoreToolsPackager.Export(plan)` 内の `#pragma warning disable CS0618` | 抑止ごと削除する |
+| `AssetStoreToolsPackagePlan.Mode` | 削除する |
+| `AssetStoreToolsPackageWindow` | `Export Mode` の `EnumFlagsField` と `DrawCombineDeprecationHelp` を削除する |
+| `AssetStoreToolsPackageConfirmWindow` | `Export Mode` の表示行を削除する |
+| ワークスペースの `Documentation/DesignPhilosophy.md` | enum 命名の実例から `PackageModeEnum` を外す |
+
+**旧シグネチャを `[Obsolete]` のシムとして残せません。** `PackageModeEnum` 自体が消えるため、旧シグネチャは型として成立しないためです。メジャー更新で直接削除し、CHANGELOG の `### Breaking` へ移行方法を明記します。
 
 ### 「未定」について
 

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -149,7 +149,7 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
    | 項目 | 内容 |
    | --- | --- |
    | Export Mode `Singles` | 選んだフォルダを個別の `.unitypackage` として出力する |
-   | Export Mode `Combine` | 選んだフォルダを1つの `.unitypackage` にまとめて出力する |
+   | Export Mode `Combine` | **廃止予定。** 選んだフォルダを1つの `.unitypackage` にまとめて出力する。差分インポートの対象にならない（→[非推奨APIと削除予定](./Deprecations.md)） |
    | Create ZIP File | 出力フォルダ全体をZIP化する |
    | Used Dependencies | プロジェクト内で実際に使用しているアセットと、強制包含拡張子だけに絞る |
 
@@ -176,7 +176,7 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 
 - **`PackageVersions.json` と `ExportedVersion.json` は版管理へ含めてください。** インポート先での比較に使います。
 - リビジョンは「実際には変わっていないのに増える」ことがあります。Unityが再インポートしただけでも加算されるためです。これは**不要なインポートが1回余分に起きる方向**の誤りで、「変わったのに増えない」逆方向の誤りは起きません。
-- **統合パッケージ（`Export Mode = Combine`）は差分インポートの対象になりません。** ディレクトリ単位で取り出せないためです。`Combine` だけで出力すると `PackageManifest.json` は作られず、Consoleへ警告が出ます。
+- **統合パッケージ（`Export Mode = Combine`）は差分インポートの対象になりません。** ディレクトリ単位で取り出せないためです。`Combine` だけで出力すると `PackageManifest.json` は作られず、Consoleへ警告が出ます。**`Combine` は廃止予定です**（3.4.0で非推奨、次のメジャー更新で削除）。`Singles` を使用してください。
 - リビジョンを手で編集する場合、負の値は0として扱われます。
 
 ### 出力全般の注意点

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageWindow.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageWindow.cs
@@ -99,6 +99,7 @@ namespace SymphonyFrameWork.Editor
 
             EditorGUILayout.Space();
             _packageMode = (PackageModeEnum)EditorGUILayout.EnumFlagsField("Export Mode", _packageMode);
+            DrawCombineDeprecationHelp();
             _createZip = EditorGUILayout.ToggleLeft("Create ZIP File", _createZip);
             _usedDependencies = EditorGUILayout.ToggleLeft("Used Dependencies", _usedDependencies);
 
@@ -131,6 +132,28 @@ namespace SymphonyFrameWork.Editor
                     }
                 }
             }
+        }
+
+        /// <summary>
+        ///     Combineが選択されている場合に、廃止予定であることを表示する。
+        /// </summary>
+        /// <remarks>
+        ///     選択自体は禁止しない。既存の運用を突然壊さず、移行期間を設けるため。
+        /// </remarks>
+        private void DrawCombineDeprecationHelp()
+        {
+#pragma warning disable CS0618
+            if ((_packageMode & PackageModeEnum.Combine) == 0)
+            {
+                return;
+            }
+#pragma warning restore CS0618
+
+            EditorGUILayout.HelpBox(
+                "Combine は廃止予定です。Singles を使用してください。\n"
+                + "統合パッケージはディレクトリ単位で取り出せないため、差分インポートの対象になりません。"
+                + "Combine だけを指定した場合、PackageManifest.json は作られません。",
+                MessageType.Warning);
         }
 
         /// <summary>

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
@@ -38,7 +38,16 @@ namespace SymphonyFrameWork.Editor
             /// <summary> 選択ディレクトリを個別のパッケージとして出力する。 </summary>
             Singles = 1 << 0,
 
-            /// <summary> 選択ディレクトリを1つの統合パッケージとして出力する。 </summary>
+            /// <summary>
+            ///     選択ディレクトリを1つの統合パッケージとして出力する。
+            /// </summary>
+            /// <remarks>
+            ///     統合パッケージはディレクトリ単位で取り出せないため、差分インポートの単位にならない。
+            ///     この形式で出力してもPackageManifest.jsonは作られない。
+            /// </remarks>
+            [Obsolete(
+                "差分インポートに対応しないため廃止予定です。" + nameof(Singles) + "を使用してください。",
+                error: false)]
             Combine = 1 << 1,
         }
 
@@ -197,23 +206,31 @@ namespace SymphonyFrameWork.Editor
                 ExportPackage(context, plan);
             }
 
+            // 非推奨のCombineは削除まで動作を維持する必要があるため、
+            // 廃止予定の警告をここでは抑止する。利用側の指定に対しては警告が出る。
+#pragma warning disable CS0618
             if ((plan.Mode & PackageModeEnum.Combine) != 0)
             {
                 CreateCombinedPackage(context, plan);
             }
+#pragma warning restore CS0618
 
             // マニフェストは個別出力のときだけ書く。ZIPへ含めるためZIP化より前に書く。
             if ((plan.Mode & PackageModeEnum.Singles) != 0)
             {
                 WriteManifest(context, plan);
             }
+#pragma warning disable CS0618
             else if ((plan.Mode & PackageModeEnum.Combine) != 0)
             {
                 Debug.LogWarning(
                     $"[{nameof(AssetStoreToolsPackager)}]\n"
                     + "統合パッケージだけの出力は差分インポートの対象になりません。"
-                    + "ディレクトリ単位で取り出せないためです。");
+                    + "ディレクトリ単位で取り出せないためです。"
+                    + $"\n{nameof(PackageModeEnum)}.{nameof(PackageModeEnum.Combine)}は廃止予定です。"
+                    + $"{nameof(PackageModeEnum.Singles)}を使用してください。");
             }
+#pragma warning restore CS0618
 
             if (plan.CreateZip)
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Issue: #119

Issue #119 の Round 3a です。統合パッケージ出力（`Combine`）を**非推奨にします。削除はしません。**

設計書では2タブ化・差分インポートと同じ Round にしていましたが、Obsolete 化は単独で検証でき単独でリリースできるため切り出しました。2タブ化と差分インポートは Round 3b（3.5.0）で扱います。

## なぜ非推奨にするか

統合パッケージは全ディレクトリを1つの `.unitypackage` へまとめるため、**ディレクトリ単位で取り出せず、差分インポートの単位になりません。**

3.3.0 で追加したバージョンログは、パッケージ単位のリビジョンを比較して「更新されたものだけを取り込む」ための仕組みです。`Combine` で出力したパッケージはこの比較に載せられないため、**3.3.0 の時点で `Combine` だけの出力では `PackageManifest.json` を作っていません。** 実態として差分インポートの対象外である状態を、型の上でも明示しました。

## 変更内容

- `PackageModeEnum.Combine` へ `[Obsolete(..., error: false)]` を付与
- パッケージ内部の使用箇所（`Export` の分岐2か所、ウィンドウの警告表示）は `#pragma warning disable CS0618` で抑止。**削除まで動作を維持する必要があるため**であり、利用側の指定に対しては警告が出る
- Packager ウィンドウで `Combine` を選ぶと、廃止予定である旨を `HelpBox` で表示。**選択自体は禁止していない**（既存の運用を突然壊さず、移行期間を設けるため）
- `Combine` だけで出力したときのConsole警告に、廃止予定である旨と移行先を追記
- `Documentation~/Deprecations.md` へ行を追加し、**削除時に一緒に直す箇所を一覧で記録**（`CreateCombinedPackage`、`Plan.Mode`、両ウィンドウの `Export Mode`、`#pragma` の抑止、ワークスペースの `DesignPhilosophy.md`）
- `Documentation~/EditorTools.md` の Packager の節に廃止予定を明記

## 削除しない理由

`PackageModeEnum` は `public` なので、削除にはメジャー更新（4.0.0）が必要です。Editor 専用ツール1つのためにメジャーを消費せず、他の破壊的変更とまとめて出します。

削除時に旧シグネチャを `[Obsolete]` のシムとして残せない点も記録済みです（`PackageModeEnum` 自体が消えるため、旧シグネチャが型として成立しない）。

## 検証

- `release_round.py preflight`: ブランチ / `version` と CHANGELOG の一致（3.4.0）/ `.cs` の UTF-8 BOM 2件 / `.meta` の対 / Runtime・Core からの `UnityEditor` 参照 / テスト asmdef の `UNITY_INCLUDE_TESTS` — すべて通過
- `uloop-compile`: エラー0、**パッケージ内の警告0**（`#pragma` が効いており、内部使用でCS0618が出ない）
- EditMode テスト: **254件中254件成功**（`Success=true` / `Failed=0` / `Skipped=0`）。連続2回で確認
- **利用側から警告が出ることを実測**: ホスト側へ `Combine` を使う一時ファイルを置いてコンパイルし、次の警告が出ることを確認。確認後に削除し、残骸が無いことを `git status` で確認済み

  ```
  warning CS0618: 'AssetStoreToolsPackager.PackageModeEnum.Combine' is obsolete:
  '差分インポートに対応しないため廃止予定です。Singlesを使用してください。'
  ```

未確認（人の操作が必要）: Packager ウィンドウで `Combine` を選んだときの `HelpBox` の表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
