### PR TITLE
[add]パッケージ出力手順のパイプライン基盤を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [3.6.0] - 2026-08-05
+Asset Store Tools Packager の出力手順を、順序付きの Strategy 列（パイプライン）として組み替えられるようにしました。**ウィンドウの操作と出力結果は 3.5.0 と同じで、公開APIは追加だけです。**
+
+### Add
+
+- **パッケージ出力の手順を表す拡張点 `AssetStoreToolsPackageStepStrategy` を追加しました。** 利用側でこれを継承すると、独自の手順をパッケージ出力へ差し込めます。
+
+  これまでの出力内容は `Export Mode` / `Create ZIP File` / `Used Dependencies` の 3 つの固定オプションでしか表現できず、**ZIP の代わりに独自の圧縮をかける、出力後に社内ツールへ通知する、といった要求へフレームワークを書き換えずに応える手段がありませんでした。**
+
+  手順は `Plan` と `Execute` の 2 段階を持ちます。パイプライン全体で「全手順の `Plan`」→「全手順の `Execute`」の順に走り、各段階の中では並び順どおりに実行されます。**2 段階にしているのは、出力前に確認ウィンドウへ内容を提示するためです。** 絞り込みが `Execute` の中で起きると、提示した一覧と実物が食い違います。
+
+  | 既定の手順 | 段階 | 役割 |
+  | --- | --- | --- |
+  | `AssetStoreToolsUsedDependenciesStrategy` | `Plan` | 使用中アセットと強制包含拡張子だけへ絞る |
+  | `AssetStoreToolsSinglePackageStrategy` | `Execute` | ディレクトリごとに出力し、`PackageManifest.json` を書く |
+  | `AssetStoreToolsCombinePackageStrategy` | `Execute` | 全ディレクトリを 1 つへまとめる |
+  | `AssetStoreToolsCreateZipStrategy` | `Execute` | 出力フォルダを ZIP 化する |
+
+  **1 つの手順が例外を投げても、記録して次の手順へ進みます。** 利用側の自作手順の失敗で、フレームワーク側の出力まで巻き添えにしないためです。
+
+- **手順の並びを保持する `AssetStoreToolsPackagePipeline`（`ScriptableObject`）を追加しました。** `Assets > Create > SymphonyFrameWork > Asset Store Tools Package Pipeline` から作成でき、`[SerializeReference]` と サブクラスセレクターで手順を選べます。
+
+- **`AssetStoreToolsPackager.Export(string[], AssetStoreToolsPackagePipeline)` を追加しました。** パイプラインを指定して出力します。
+
+- **`AssetStoreToolsPackagePlan` と `AssetStoreToolsPackagePlanEntry` を公開しました。** 自作の手順が出力対象を絞り込むために必要なためです。
+
+  **`AssetStoreToolsPackagePlanEntry.FilterAssetPaths` は絞り込みしかできません。** 手順がアセットを追加できると、確認ウィンドウで提示した内容より多くのものが出力され得るためです。計画そのものを組み立てられるのはフレームワーク内部だけです。
+
+- **`AssetStoreToolsPackageExportContext` を追加しました。** `Execute` 段階の手順が受け取る、出力先パスと確定済みの計画です。
+
+### Change
+
+- **確認ウィンドウの表示を `Export Mode` / `Create ZIP` / `Used Dependencies` の 3 行から、パイプライン名と手順の並びへ変えました。** 手順は並び順のまま表示します。**並べ替えは行いません。** 誤った順序（たとえば ZIP 化を出力より前へ置く）をそのまま見せることが、順序の誤りに気づく手段になるためです。
+
+- **出力対象の収集を 1 本にまとめました。** 絞り込みの有無で収集方法が分かれていたものを、「収集」と「絞り込み」の合成へ変えています。合成結果は 3.5.0 と一致します。
+
+  **絞り込みを行わない場合だけ、確認ウィンドウの一覧へ `.bundle` や `.framework` などフォルダ形式のアセットが増えます。** この経路の実際の出力はディレクトリ単位の再帰なので、もともと出力には含まれていました。提示内容が実物へ近づく変化で、**出力される `.unitypackage` の中身は変わりません。**
+
+### Deprecated
+
+- **`AssetStoreToolsPackageContext` を非推奨にしました。** `ref struct` はフィールドへ保持できず、パイプラインの拡張点へ渡せないためです。
+
+  **移行方法**: `AssetStoreToolsPackageExportContext` を使用してください。プロパティ名と意味（`PackageName`、`ExportRoot`、`ExportLocalPath`、`ExportFullPath`、`DateTime`）は同じです。`ExportDirectories` は `Plan.Entries` の `DirectoryPath` から取得できます。
+
 ## [3.5.0] - 2026-08-05
 Asset Store Tools Packager を2タブ構成にし、**更新されたパッケージだけを取り込む差分インポート**を追加しました。**Runtime の公開APIとセーブデータ形式は変更していません。**
 

--- a/Documentation~/Deprecations.md
+++ b/Documentation~/Deprecations.md
@@ -24,21 +24,23 @@ CHANGELOGだけでは、非推奨化した版まで遡らないと一覧でき�
 | `SymphonyTween.TweeningLerp<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | `Task` を返す旧型式。移行先は `Awaitable` を返す |
 | `SymphonyTween.TweeningCurve<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | 同上 |
 | `EditorSymphonyConstant.ASSET_STORE_TOOLS_IGNORE_FILE` | `Core/Editor/EditorSymphonyConstant.cs` | `EditorSymphonyConstant.ASSET_STORE_TOOLS_CONFIG_FILE_NAME` | 3.1.0 | 次のメジャー更新 | 削除時は `AssetStoreToolsPackagerConfigStore` の `ignore.txt` 移行処理（`IGNORE_FILE_NAME`、`ReadIgnoreFile`、`CreateConfigFile` の移行分岐）も一緒に削除する |
-| `AssetStoreToolsPackager.PackageModeEnum.Combine` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `PackageModeEnum.Singles` | 3.4.0 | 次のメジャー更新 | **削除時は `PackageModeEnum` ごと削除する。** 下記「Combineの削除手順」を参照 |
+| `AssetStoreToolsPackager.PackageModeEnum.Combine` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `AssetStoreToolsCombinePackageStrategy` | 3.4.0 | 次のメジャー更新 | **enum の選択肢としては消すが、統合パッケージ出力そのものは Strategy として残す。** 下記「Combineの削除手順」を参照 |
+| `AssetStoreToolsPackageContext` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageContext.cs` | `AssetStoreToolsPackageExportContext` | 3.6.0 | 次のメジャー更新 | `ref struct` はフィールドへ保持できず、パイプラインの拡張点へ渡せない。3.6.0 以降フレームワーク内部では使用していない |
 
 ### Combineの削除手順
 
 `Combine` を削除すると `PackageModeEnum` に `Singles` と `Nothing` しか残らず、enum 自体が意味を失います。**次のメジャー更新で enum ごと削除します。** そのとき一緒に直す箇所を記録しておきます。
 
+**削除するのは enum の選択肢であって、統合パッケージ出力の機能ではありません。** 3.6.0 で `AssetStoreToolsCombinePackageStrategy` として残しました。「差分インポートの単位にならない」という 3.4.0 の判断は変わらないため、**既定テンプレートには含めず、必要な利用者が自分でパイプラインへ追加する**位置付けです（Issue #124）。この Strategy に `[Obsolete]` は付けていません。
+
 | 対象 | 変更内容 |
 | --- | --- |
 | `AssetStoreToolsPackager.PackageModeEnum` | 削除する |
-| `AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` | `Export(string[], bool, bool)` へ変更する |
-| `AssetStoreToolsPackager.CreateCombinedPackage` | 削除する |
-| `AssetStoreToolsPackager.Export(plan)` 内の `#pragma warning disable CS0618` | 抑止ごと削除する |
-| `AssetStoreToolsPackagePlan.Mode` | 削除する |
-| `AssetStoreToolsPackageWindow` | `Export Mode` の `EnumFlagsField` と `DrawCombineDeprecationHelp` を削除する |
-| `AssetStoreToolsPackageConfirmWindow` | `Export Mode` の表示行を削除する |
+| `AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` | 削除する。代替は `Export(string[], AssetStoreToolsPackagePipeline)`（3.6.0 で追加済み） |
+| `AssetStoreToolsPackager.CreatePlan(string[], PackageModeEnum, bool, bool)` | 削除する |
+| `AssetStoreToolsPackager.CreateStepsFromOptions` と `LEGACY_PIPELINE_NAME` | 削除する |
+| `AssetStoreToolsPackager` 内の `#pragma warning disable CS0618` | 抑止ごと削除する |
+| `AssetStoreToolsPackageWindow` | `Export Mode` の `EnumFlagsField` と `DrawCombineDeprecationHelp` を削除する（3.7.0 でパイプラインのポップアップへ置き換え予定） |
 | ワークスペースの `Documentation/DesignPhilosophy.md` | enum 命名の実例から `PackageModeEnum` を外す |
 
 **旧シグネチャを `[Obsolete]` のシムとして残せません。** `PackageModeEnum` 自体が消えるため、旧シグネチャは型として成立しないためです。メジャー更新で直接削除し、CHANGELOG の `### Breaking` へ移行方法を明記します。

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -17,6 +17,7 @@ Editor機能はGUI操作を入口とするため、この文書にコード例�
 | [Save System設定](#save-system設定) | `Project Settings > SymphonyFrameWork > Save System` |
 | [Asset Store Tools Packager設定](#asset-store-tools-packager設定) | `Project Settings > SymphonyFrameWork > Asset Store Tools Packager` |
 | [Asset Store Tools Packager](#asset-store-tools-packager) | `Tools > SymphonyFrameWork > ExportAssetStoreToolsFolder` |
+| [出力手順のパイプライン](#出力手順のパイプライン) | `Assets > Create > SymphonyFrameWork > Asset Store Tools Package Pipeline` |
 | [AutoEnumGenerator](#autoenumgenerator) | 自動実行。手動生成はSymphony Administratorから |
 | [FolderGenerator](#foldergenerator) | `Tools > SymphonyFrameWork > FolderGenerator` |
 | [AssemblyGenerator](#assemblygenerator) | メニューなし。他のEditor機能から呼ばれる |
@@ -161,6 +162,49 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 4. `Export` で実行、`Cancel` で中止
 
 **出力先**: `<Exported Packages Path>/Export_AssetStoreToolsPackage_<日時>/`
+
+### 出力手順のパイプライン
+
+3.6.0 から、出力手順を順序付きの Strategy 列として組み替えられます。
+
+**入口**: `Assets > Create > SymphonyFrameWork > Asset Store Tools Package Pipeline`
+
+作成したアセットの `Steps` へ、サブクラスセレクターで手順を並べます。
+
+| 手順 | 段階 | 役割 |
+| --- | --- | --- |
+| `AssetStoreToolsUsedDependenciesStrategy` | `Plan` | 使用中アセットと強制包含拡張子だけへ絞る |
+| `AssetStoreToolsSinglePackageStrategy` | `Execute` | ディレクトリごとに出力し、`PackageManifest.json` を書く |
+| `AssetStoreToolsCombinePackageStrategy` | `Execute` | 全ディレクトリを1つへまとめる |
+| `AssetStoreToolsCreateZipStrategy` | `Execute` | 出力フォルダをZIP化する |
+
+**実行順**: パイプライン全体で「全手順の `Plan`」→「全手順の `Execute`」の順に走り、各段階の中では並び順どおりに実行されます。**絞り込みは並びのどこにあっても出力より先に走ります。**
+
+**注意点**:
+
+- **`Execute` 段階の順序は利用者の責任です。** `AssetStoreToolsCreateZipStrategy` を出力より前へ置くと、空のフォルダを圧縮します。フレームワークは並べ替えません。確認ウィンドウが並び順をそのまま表示します。
+- **`AssetStoreToolsCombinePackageStrategy` は差分インポートの対象になりません。** ディレクトリ単位で取り出せないためです。この手順だけのパイプラインでは `PackageManifest.json` が作られず、実行時に警告が出ます。
+- **1つの手順が例外を投げても、記録して次の手順へ進みます。** 自作手順の失敗でフレームワーク側の出力まで止めないためです。
+- **3.6.0 時点では、Export タブの操作は上の固定オプションのままです。** ウィンドウからパイプラインを選べるようになるのは 3.7.0 の予定です。コードから使う場合は `AssetStoreToolsPackager.Export(string[], AssetStoreToolsPackagePipeline)` を呼びます。
+
+**自作の手順を追加する**: `AssetStoreToolsPackageStepStrategy` を継承し、`[Serializable]` を付けます。置き場は `SymphonyFrameWork.Editor` を参照する Editor 用 asmdef です。
+
+```csharp
+[Serializable]
+public sealed class NotifyStrategy : AssetStoreToolsPackageStepStrategy
+{
+    public override string DisplayName => "Notify";
+
+    // 別アセンブリからのオーバーライドは protected で宣言する。
+    // protected internal のままではコンパイルエラー（CS0507）になる。
+    protected override void Execute(AssetStoreToolsPackageExportContext context)
+    {
+        // context.ExportFullPath へ出力済み。
+    }
+}
+```
+
+出力対象を絞り込む手順は `Plan` をオーバーライドし、`plan.Entries` の各要素へ `FilterAssetPaths` を呼びます。**絞り込みしかできません。** 手順がアセットを追加できると、確認ウィンドウで提示した内容より多くのものが出力され得るためです。
 
 ### Import タブ
 

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageConfirmWindow.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageConfirmWindow.cs
@@ -51,9 +51,8 @@ namespace SymphonyFrameWork.Editor
 
             GUILayout.Label("以下のアセットを出力します", EditorStyles.boldLabel);
 
-            EditorGUILayout.LabelField("Export Mode", _plan.Mode.ToString());
-            EditorGUILayout.LabelField("Create ZIP", _plan.CreateZip ? "Yes" : "No");
-            EditorGUILayout.LabelField("Used Dependencies", _plan.UsedDependencies ? "Yes" : "No");
+            EditorGUILayout.LabelField("Pipeline", _plan.PipelineName);
+            EditorGUILayout.LabelField("Steps", BuildStepsLabel(_plan));
             EditorGUILayout.LabelField("Total Assets", _plan.TotalAssetCount.ToString());
 
             EditorGUILayout.Space();
@@ -95,6 +94,24 @@ namespace SymphonyFrameWork.Editor
             {
                 _onConfirmed?.Invoke();
             }
+        }
+
+        /// <summary>
+        ///     実行する手順を並び順のまま1行へ組み立てる。
+        /// </summary>
+        /// <remarks>
+        ///     並べ替えは行わない。誤った順序をそのまま見せることが、順序の誤りに気づく手段になる。
+        /// </remarks>
+        /// <param name="plan"> 提示する出力計画。 </param>
+        /// <returns> 矢印区切りの手順名。手順が無い場合はその旨を示す文字列。 </returns>
+        private static string BuildStepsLabel(AssetStoreToolsPackagePlan plan)
+        {
+            if (plan.Steps.Count == 0)
+            {
+                return "（手順が設定されていません）";
+            }
+
+            return string.Join(" → ", plan.Steps.Select(step => step.DisplayName));
         }
 
         /// <summary> 計画のディレクトリごとにツリーのルートを組み立てる。 </summary>

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageContext.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageContext.cs
@@ -5,6 +5,13 @@ using UnityEngine;
 namespace SymphonyFrameWork.Editor
 {
     /// <summary> 1回のパッケージ出力で共有する名前、日時、入出力パスを保持する。 </summary>
+    /// <remarks>
+    ///     <c>ref struct</c>はフィールドへ保持できず、パイプラインの拡張点へ渡せないため、
+    ///     <see cref="AssetStoreToolsPackageExportContext" />へ置き換えた。
+    /// </remarks>
+    [Obsolete(
+        "パイプラインへ移行しました。" + nameof(AssetStoreToolsPackageExportContext) + "を使用してください。",
+        error: false)]
     public readonly ref struct AssetStoreToolsPackageContext
     {
         /// <summary> 出力元と出力先から不変のパッケージ処理コンテキストを生成する。 </summary>

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagePlan.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagePlan.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using static SymphonyFrameWork.Editor.AssetStoreToolsPackager;
 
 namespace SymphonyFrameWork.Editor
 {
@@ -9,41 +9,114 @@ namespace SymphonyFrameWork.Editor
     /// </summary>
     /// <remarks>
     ///     出力前に内容を提示するため、実行と切り離して保持できる形にしている。
+    ///     計画を組み立てられるのは<see cref="AssetStoreToolsPackagePipelineRunner" />だけで、
+    ///     利用側のStrategyからは<see cref="AssetStoreToolsPackagePlanEntry.FilterAssetPaths" />で
+    ///     出力対象を絞り込むことだけができる。
     /// </remarks>
-    internal sealed class AssetStoreToolsPackagePlan
+    public sealed class AssetStoreToolsPackagePlan
     {
-        /// <summary> 個別出力と統合出力のどちらを行うか。 </summary>
-        public PackageModeEnum Mode;
+        /// <summary> 計画を組み立てたパイプラインの名前。 </summary>
+        public string PipelineName { get; }
 
-        /// <summary> 出力後にZIP化するか。 </summary>
-        public bool CreateZip;
-
-        /// <summary> 使用中アセットと強制包含拡張子だけへ絞るか。 </summary>
-        public bool UsedDependencies;
+        /// <summary> 実行する手順。null要素は除去済み。 </summary>
+        public IReadOnlyList<AssetStoreToolsPackageStepStrategy> Steps { get; }
 
         /// <summary> ディレクトリごとの出力内容。 </summary>
-        public IReadOnlyList<AssetStoreToolsPackagePlanEntry> Entries = new List<AssetStoreToolsPackagePlanEntry>();
+        public IReadOnlyList<AssetStoreToolsPackagePlanEntry> Entries { get; }
+
+        /// <summary> 依存関係に含まれなくても強制的にパッケージへ含める拡張子。 </summary>
+        public IReadOnlyList<string> ForceIncludeExtensions { get; }
 
         /// <summary> 出力に含まれるアセットの総数。ディレクトリ間の重複は数えない。 </summary>
         public int TotalAssetCount => Entries
             .SelectMany(entry => entry.AssetPaths)
-            .Distinct()
+            .Distinct(StringComparer.Ordinal)
             .Count();
+
+        /// <summary>
+        ///     いずれかのディレクトリでPlan段階の絞り込みが行われたかを示す。
+        /// </summary>
+        /// <remarks>
+        ///     ディレクトリ単位ではなく計画全体で1つの出力を作るStrategyが、
+        ///     ディレクトリ丸ごとの出力と明示指定の出力を切り替えるために使う。
+        ///     1件でも絞り込まれていれば明示指定を選ぶ。丸ごと出力を選ぶと、
+        ///     確認ウィンドウで提示した内容より多くのアセットが出力され得るため。
+        /// </remarks>
+        public bool IsFiltered => Entries.Any(entry => entry.IsFiltered);
+
+        /// <summary> ランナーが確定した内容から計画を生成する。 </summary>
+        /// <param name="pipelineName"> 計画を組み立てたパイプラインの名前。 </param>
+        /// <param name="steps"> 実行する手順。null要素は呼び出し側で除去しておく。 </param>
+        /// <param name="entries"> ディレクトリごとの出力内容。 </param>
+        /// <param name="forceIncludeExtensions"> 強制的にパッケージへ含める拡張子。 </param>
+        internal AssetStoreToolsPackagePlan(
+            string pipelineName,
+            IReadOnlyList<AssetStoreToolsPackageStepStrategy> steps,
+            IReadOnlyList<AssetStoreToolsPackagePlanEntry> entries,
+            IReadOnlyList<string> forceIncludeExtensions)
+        {
+            PipelineName = pipelineName ?? string.Empty;
+            Steps = steps ?? Array.Empty<AssetStoreToolsPackageStepStrategy>();
+            Entries = entries ?? Array.Empty<AssetStoreToolsPackagePlanEntry>();
+            ForceIncludeExtensions = forceIncludeExtensions ?? Array.Empty<string>();
+        }
     }
 
     /// <summary> 出力単位となるディレクトリ1件分の内容。 </summary>
-    internal sealed class AssetStoreToolsPackagePlanEntry
+    public sealed class AssetStoreToolsPackagePlanEntry
     {
         /// <summary> 出力単位となるディレクトリのパス。 </summary>
-        public string DirectoryPath;
+        public string DirectoryPath { get; }
 
         /// <summary> パッケージ名と表示に使うディレクトリ名。 </summary>
-        public string Name;
+        public string Name { get; }
 
         /// <summary> 計画を組んだ時点のリビジョン。出力時バージョンとマニフェストへ記録する。 </summary>
-        public int Version;
+        public int Version { get; }
 
         /// <summary> このディレクトリから出力されるアセットのパス一覧。 </summary>
-        public IReadOnlyList<string> AssetPaths = new List<string>();
+        public IReadOnlyList<string> AssetPaths { get; private set; }
+
+        /// <summary> Plan段階で出力対象が絞り込まれたかを示す。 </summary>
+        public bool IsFiltered { get; private set; }
+
+        /// <summary>
+        ///     条件に合わないアセットを出力対象から外す。
+        /// </summary>
+        /// <remarks>
+        ///     絞り込みしかできない。アセットを追加できると、確認ウィンドウで提示した内容より
+        ///     多くのものが出力され得るため。
+        /// </remarks>
+        /// <param name="predicate"> 出力対象として残す場合にtrueを返す判定。 </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="predicate" />がnullの場合。 </exception>
+        public void FilterAssetPaths(Func<string, bool> predicate)
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            AssetPaths = AssetPaths
+                .Where(path => predicate(path))
+                .ToArray();
+            IsFiltered = true;
+        }
+
+        /// <summary> ランナーが収集した内容から出力単位を生成する。 </summary>
+        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
+        /// <param name="name"> パッケージ名と表示に使うディレクトリ名。 </param>
+        /// <param name="version"> 計画を組んだ時点のリビジョン。 </param>
+        /// <param name="assetPaths"> 絞り込み前の出力対象アセット。 </param>
+        internal AssetStoreToolsPackagePlanEntry(
+            string directoryPath,
+            string name,
+            int version,
+            IReadOnlyList<string> assetPaths)
+        {
+            DirectoryPath = directoryPath;
+            Name = name;
+            Version = version;
+            AssetPaths = assetPaths ?? Array.Empty<string>();
+        }
     }
 }

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
@@ -2,11 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using CompressionLevel = System.IO.Compression.CompressionLevel;
 
 namespace SymphonyFrameWork.Editor
 {
@@ -99,7 +96,25 @@ namespace SymphonyFrameWork.Editor
             return results;
         }
 
+        /// <summary> 指定ディレクトリをパイプラインの手順どおりに出力する。 </summary>
+        /// <param name="directories"> 出力対象のディレクトリ。 </param>
+        /// <param name="pipeline"> 実行する手順を持つパイプライン。 </param>
+        public static void Export(string[] directories, AssetStoreToolsPackagePipeline pipeline)
+        {
+            AssetStoreToolsPackagePlan plan = CreatePlan(directories, pipeline);
+            if (plan == null)
+            {
+                return;
+            }
+
+            Export(plan);
+        }
+
         /// <summary> 指定ディレクトリを選択された形式で出力し、必要に応じてZIP化する。 </summary>
+        /// <param name="directories"> 出力対象のディレクトリ。 </param>
+        /// <param name="mode"> 個別出力と統合出力の指定。 </param>
+        /// <param name="createZip"> 出力後にZIP化するか。 </param>
+        /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
         public static void Export(string[] directories, PackageModeEnum mode, bool createZip = false, bool usedDependencies = false)
         {
             AssetStoreToolsPackagePlan plan = CreatePlan(directories, mode, createZip, usedDependencies);
@@ -115,6 +130,26 @@ namespace SymphonyFrameWork.Editor
         ///     出力内容を確定した計画を組み立てる。この時点ではファイルを出力しない。
         /// </summary>
         /// <param name="directories"> 出力対象のディレクトリ。 </param>
+        /// <param name="pipeline"> 実行する手順を持つパイプライン。 </param>
+        /// <returns> 出力計画。対象が無い場合や設定を読み込めない場合はnull。 </returns>
+        internal static AssetStoreToolsPackagePlan CreatePlan(
+            string[] directories,
+            AssetStoreToolsPackagePipeline pipeline)
+        {
+            if (pipeline == null)
+            {
+                Debug.LogError($"[{nameof(AssetStoreToolsPackager)}]\nパイプラインが指定されていません。");
+                return null;
+            }
+
+            return AssetStoreToolsPackagePipelineRunner.CreatePlan(
+                directories, pipeline.Steps, pipeline.name);
+        }
+
+        /// <summary>
+        ///     旧来のフラグ指定から計画を組み立てる。この時点ではファイルを出力しない。
+        /// </summary>
+        /// <param name="directories"> 出力対象のディレクトリ。 </param>
         /// <param name="mode"> 個別出力と統合出力の指定。 </param>
         /// <param name="createZip"> 出力後にZIP化するか。 </param>
         /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
@@ -125,439 +160,19 @@ namespace SymphonyFrameWork.Editor
             bool createZip,
             bool usedDependencies)
         {
-            if (directories == null || directories.Length == 0)
-            {
-                Debug.LogWarning("パッケージ化するフォルダが存在しませんでした。");
-                return null;
-            }
-
-            AssetStoreToolsPackagerConfig config = AssetStoreToolsPackagerConfigStore.Load();
-            if (config == null)
-            {
-                Debug.LogError($"[{nameof(AssetStoreToolsPackager)}]\n設定を読み込めなかったためパッケージを出力しませんでした。");
-                return null;
-            }
-
-            HashSet<string> usedAssetPaths = usedDependencies
-                ? GetProjectUsedDependencies(AssetStoreToolsPackagerData.AssetStoreToolsPath)
-                : null;
-
-            // 読み込めない場合もリビジョン0として出力は続行する。
-            // 差分インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
-            AssetStoreToolsVersionLog versionLog = AssetStoreToolsVersionLogStore.Load();
-
-            List<AssetStoreToolsPackagePlanEntry> entries = new();
-            foreach (string dir in directories)
-            {
-                string name = Path.GetFileName(dir);
-                string[] assetPaths = usedAssetPaths != null
-                    ? CollectExportAssets(dir, usedAssetPaths, config.ForceIncludeExtensions)
-                    : CollectAllAssets(dir);
-
-                entries.Add(new AssetStoreToolsPackagePlanEntry
-                {
-                    DirectoryPath = dir,
-                    Name = name,
-                    Version = versionLog?.GetVersion(name) ?? 0,
-                    AssetPaths = assetPaths,
-                });
-            }
-
-            return new AssetStoreToolsPackagePlan
-            {
-                Mode = mode,
-                CreateZip = createZip,
-                UsedDependencies = usedDependencies,
-                Entries = entries,
-            };
+            return AssetStoreToolsPackagePipelineRunner.CreatePlan(
+                directories,
+                CreateStepsFromOptions(mode, createZip, usedDependencies),
+                LEGACY_PIPELINE_NAME);
         }
 
         /// <summary>
-        ///     確定済みの計画に従ってパッケージを出力し、必要に応じてZIP化する。
+        ///     確定済みの計画に従ってパイプラインを実行する。
         /// </summary>
         /// <param name="plan"> 出力する計画。 </param>
         internal static void Export(AssetStoreToolsPackagePlan plan)
         {
-            if (plan == null || plan.Entries.Count == 0)
-            {
-                Debug.LogWarning("パッケージ化するフォルダが存在しませんでした。");
-                return;
-            }
-
-            var context = new AssetStoreToolsPackageContext(
-                PACKAGE_NAME,
-                AssetStoreToolsPackagerData.ExportedPackagesPath,
-                plan.Entries.Select(entry => entry.DirectoryPath).ToArray()
-            );
-
-            // 出力フォルダ作成
-            if (!Directory.Exists(context.ExportFullPath))
-            {
-                Directory.CreateDirectory(context.ExportFullPath);
-            }
-
-            // 出力時バージョンを先に書き、AssetDatabaseへ載せてからパッケージ化する。
-            // Refreshを省くと新規ファイルがAssetDatabaseに載らず、Recurseでも明示指定でも出力されない。
-            WriteExportedVersions(plan);
-            AssetDatabase.Refresh();
-
-            if ((plan.Mode & PackageModeEnum.Singles) != 0)
-            {
-                ExportPackage(context, plan);
-            }
-
-            // 非推奨のCombineは削除まで動作を維持する必要があるため、
-            // 廃止予定の警告をここでは抑止する。利用側の指定に対しては警告が出る。
-#pragma warning disable CS0618
-            if ((plan.Mode & PackageModeEnum.Combine) != 0)
-            {
-                CreateCombinedPackage(context, plan);
-            }
-#pragma warning restore CS0618
-
-            // マニフェストは個別出力のときだけ書く。ZIPへ含めるためZIP化より前に書く。
-            if ((plan.Mode & PackageModeEnum.Singles) != 0)
-            {
-                WriteManifest(context, plan);
-            }
-#pragma warning disable CS0618
-            else if ((plan.Mode & PackageModeEnum.Combine) != 0)
-            {
-                Debug.LogWarning(
-                    $"[{nameof(AssetStoreToolsPackager)}]\n"
-                    + "統合パッケージだけの出力は差分インポートの対象になりません。"
-                    + "ディレクトリ単位で取り出せないためです。"
-                    + $"\n{nameof(PackageModeEnum)}.{nameof(PackageModeEnum.Combine)}は廃止予定です。"
-                    + $"{nameof(PackageModeEnum.Singles)}を使用してください。");
-            }
-#pragma warning restore CS0618
-
-            if (plan.CreateZip)
-            {
-                CreateZip(context);
-            }
-
-            Debug.Log($"[{nameof(AssetStoreToolsPackager)}]\nパッケージを出力しました\npath : {context.ExportLocalPath}");
-        }
-
-
-        private const string PACKAGE_NAME = "AssetStoreToolsPackage";
-
-        /// <summary>
-        ///     出力対象アセットへ出力時バージョンファイルのパスを加える。
-        /// </summary>
-        /// <remarks>
-        ///     「Used Dependencies」の経路では計画の一覧がそのままExportPackageの引数になるため、
-        ///     ここで加えないとバージョンファイルがパッケージへ含まれない。
-        ///     計画そのものへは加えない。加えると空のディレクトリを検出できなくなる。
-        /// </remarks>
-        /// <param name="assetPaths"> 収集済みの出力対象アセット。 </param>
-        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
-        /// <returns> パスの昇順で並んだ出力対象アセットのパス。 </returns>
-        private static string[] AppendExportedVersionPath(
-            IEnumerable<string> assetPaths,
-            string directoryPath)
-        {
-            string exportedVersionPath = BuildExportedVersionPath(directoryPath);
-
-            return assetPaths
-                .Append(exportedVersionPath)
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(path => path, StringComparer.Ordinal)
-                .ToArray();
-        }
-
-        /// <summary> ディレクトリ直下の出力時バージョンファイルのパスを組み立てる。 </summary>
-        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
-        /// <returns> スラッシュ区切りのアセットパス。 </returns>
-        private static string BuildExportedVersionPath(string directoryPath)
-            => directoryPath.Replace("\\", "/").TrimEnd('/')
-               + "/" + EditorSymphonyConstant.ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME;
-
-        /// <summary>
-        ///     計画中の各ディレクトリへ出力時バージョンを書き出す。
-        /// </summary>
-        /// <remarks>
-        ///     書き込みに失敗しても出力は続行する。バージョンファイルの無いパッケージは
-        ///     インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
-        /// </remarks>
-        /// <param name="plan"> 出力する計画。 </param>
-        private static void WriteExportedVersions(AssetStoreToolsPackagePlan plan)
-        {
-            foreach (AssetStoreToolsPackagePlanEntry entry in plan.Entries)
-            {
-                AssetStoreToolsVersionLogStore.TryWriteExportedVersion(
-                    entry.DirectoryPath,
-                    entry.Name,
-                    entry.Version);
-            }
-        }
-
-        /// <summary>
-        ///     出力先フォルダへ、個別出力したパッケージ一覧のマニフェストを書き出す。
-        /// </summary>
-        /// <param name="context"> 出力先を保持するパッケージコンテキスト。 </param>
-        /// <param name="plan"> 出力した計画。 </param>
-        private static void WriteManifest(
-            in AssetStoreToolsPackageContext context,
-            AssetStoreToolsPackagePlan plan)
-        {
-            var manifest = new AssetStoreToolsPackageManifest
-            {
-                ExportedAt = AssetStoreToolsVersionLog.CreateTimestamp(),
-                Packages = plan.Entries
-                    .Select(entry => new AssetStoreToolsPackageManifestEntry
-                    {
-                        Name = entry.Name,
-                        Version = entry.Version,
-                        FileName = $"{entry.Name}.unitypackage",
-                    })
-                    .ToList(),
-            };
-
-            AssetStoreToolsVersionLogStore.TryWriteManifest(context.ExportFullPath, manifest);
-        }
-
-        /// <summary>
-        ///     個別のパッケージ生成。
-        /// </summary>
-        /// <param name="context"> 出力対象と出力先を保持するパッケージコンテキスト。 </param>
-        /// <param name="plan"> 出力内容を確定した計画。 </param>
-        private static void ExportPackage(
-            AssetStoreToolsPackageContext context,
-            AssetStoreToolsPackagePlan plan)
-        {
-            foreach (AssetStoreToolsPackagePlanEntry entry in plan.Entries)
-            {
-                try
-                {
-                    string[] exportFiles;
-                    ExportPackageOptions options;
-
-                    if (plan.UsedDependencies)
-                    {
-                        if (entry.AssetPaths.Count == 0)
-                        {
-                            Debug.LogWarning($"使用中アセットなし: {entry.DirectoryPath}");
-                            continue;
-                        }
-
-                        // 出力時バージョンは計画に含めず、ここで加える。
-                        exportFiles = AppendExportedVersionPath(entry.AssetPaths, entry.DirectoryPath);
-                        options = ExportPackageOptions.Default;
-                    }
-                    else
-                    {
-                        // 丸ごと出力する経路。計画のAssetPathsは提示用で、出力はディレクトリ単位で行う。
-                        exportFiles = new[] { entry.DirectoryPath };
-                        options = ExportPackageOptions.Recurse;
-                    }
-
-                    AssetDatabase.ExportPackage(
-                        exportFiles,
-                        Path.Combine(
-                            context.ExportLocalPath,
-                            $"{entry.Name}.unitypackage"),
-                        options
-                    );
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError($"パッケージの出力に失敗しました: {entry.DirectoryPath}\n{e}");
-                }
-            }
-        }
-
-        /// <summary>
-        ///     連結されたパッケージ生成。
-        /// </summary>
-        /// <param name="context"> 出力対象と出力先を保持するパッケージコンテキスト。 </param>
-        /// <param name="plan"> 出力内容を確定した計画。 </param>
-        private static void CreateCombinedPackage(
-            in AssetStoreToolsPackageContext context,
-            AssetStoreToolsPackagePlan plan)
-        {
-            try
-            {
-                string combinedName =
-                    $"AllPackages_{context.DateTime:yyyyMMdd_HHmmss}.unitypackage";
-
-                string[] exportFiles;
-                ExportPackageOptions options;
-
-                if (plan.UsedDependencies)
-                {
-                    // 空判定は出力時バージョンを加える前に行う。加えた後では常に非空になる。
-                    if (plan.Entries.All(entry => entry.AssetPaths.Count == 0))
-                    {
-                        Debug.LogWarning("使用中アセットが存在しないため統合パッケージを作成しませんでした。");
-                        return;
-                    }
-
-                    exportFiles = plan.Entries
-                        .SelectMany(entry =>
-                            AppendExportedVersionPath(entry.AssetPaths, entry.DirectoryPath))
-                        .Distinct()
-                        .ToArray();
-                    options = ExportPackageOptions.Default;
-                }
-                else
-                {
-                    exportFiles = context.ExportDirectories;
-                    options = ExportPackageOptions.Recurse;
-                }
-
-                AssetDatabase.ExportPackage(
-                    exportFiles,
-                    Path.Combine(context.ExportLocalPath, combinedName),
-                    options
-                );
-
-                Debug.Log($"合成パッケージ作成: {combinedName}");
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"合計パッケージの出力に失敗\n{e}");
-            }
-        }
-
-        /// <summary>
-        ///     指定フォルダをZIP化する
-        /// </summary>
-        /// <param name="context"> 圧縮対象と出力先を保持するパッケージコンテキスト。 </param>
-        private static void CreateZip(in AssetStoreToolsPackageContext context)
-        {
-            try
-            {
-                string zipFullPath = Path.Combine(context.ExportRoot, $"{context.PackageName}.zip");
-
-                if (!Directory.Exists(context.ExportFullPath))
-                {
-                    Debug.LogError($"ZIP対象フォルダが存在しません: {context.ExportFullPath}");
-                    return;
-                }
-
-                if (File.Exists(zipFullPath))
-                {
-                    File.Delete(zipFullPath);
-                }
-
-                ZipFile.CreateFromDirectory(
-                    context.ExportFullPath,
-                    zipFullPath,
-                    CompressionLevel.Optimal,
-                    true
-                );
-
-                Debug.Log($"ZIP作成完了: {zipFullPath}");
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"ZIP作成失敗\n{e}");
-            }
-        }
-
-        /// <summary>
-        /// プロジェクト内の全アセット内で一つでも依存している（＝使用している）アセットのパス一覧を取得する
-        /// </summary>
-        private static HashSet<string> GetProjectUsedDependencies(string excludedRootPath)
-        {
-            HashSet<string> usedPaths = new();
-
-            // プロジェクト内のすべての一般アセット（Assetsフォルダ以下）を検索
-            string[] allAssetGuids = AssetDatabase.FindAssets("", new[] { "Assets" });
-
-            string normalizedExcludedRootPath = excludedRootPath
-                ?.Replace("\\", "/")
-                .TrimEnd('/');
-
-            foreach (string guid in allAssetGuids)
-            {
-                string path = AssetDatabase.GUIDToAssetPath(guid);
-
-                // AssetStoreToolsは除外して依存関係を追う
-                if (!string.IsNullOrEmpty(normalizedExcludedRootPath)
-                    && (path.Equals(normalizedExcludedRootPath, StringComparison.Ordinal)
-                        || path.StartsWith(normalizedExcludedRootPath + "/", StringComparison.Ordinal)))
-                {
-                    continue;
-                }
-
-                // そのアセットが依存しているリソースをすべて取得
-                string[] dependencies = AssetDatabase.GetDependencies(path, recursive: true);
-
-                foreach (string dependency in dependencies)
-                {
-                    usedPaths.Add(dependency);
-                }
-            }
-
-            return usedPaths;
-        }
-
-        /// <summary>
-        ///     指定ディレクトリから出力対象のアセットを収集する。
-        /// </summary>
-        /// <remarks>
-        ///     ファイルシステムではなくAssetDatabaseを走査する。
-        ///     .bundleや.frameworkはUnityが単一アセットとして扱うため、
-        ///     ファイル列挙では中身のファイルしか拾えず、ExportPackageへ渡しても出力されない。
-        /// </remarks>
-        /// <param name="dir"> 収集対象のディレクトリ。 </param>
-        /// <param name="usedAssetPaths"> プロジェクト内で使用中のアセットのパス集合。 </param>
-        /// <param name="forceIncludeExtensions"> 依存関係に関わらず含める拡張子の一覧。 </param>
-        /// <returns> パスの昇順で並んだ出力対象アセットのパス。 </returns>
-        private static string[] CollectExportAssets(
-            string dir,
-            HashSet<string> usedAssetPaths,
-            IReadOnlyList<string> forceIncludeExtensions)
-        {
-            return AssetDatabase.FindAssets(string.Empty, new[] { dir })
-                .Select(AssetDatabase.GUIDToAssetPath)
-                .Where(path => !string.IsNullOrEmpty(path))
-                .Distinct()
-                .Where(path => IsExportTarget(path, usedAssetPaths, forceIncludeExtensions))
-                .OrderBy(path => path, StringComparer.Ordinal)
-                .ToArray();
-        }
-
-        /// <summary>
-        ///     指定ディレクトリ配下の全アセットを収集する。
-        /// </summary>
-        /// <remarks>
-        ///     丸ごと出力する経路で、何が含まれるかを提示するために使う。
-        /// </remarks>
-        /// <param name="dir"> 収集対象のディレクトリ。 </param>
-        /// <returns> パスの昇順で並んだアセットのパス。フォルダ自体は含まない。 </returns>
-        private static string[] CollectAllAssets(string dir)
-        {
-            return AssetDatabase.FindAssets(string.Empty, new[] { dir })
-                .Select(AssetDatabase.GUIDToAssetPath)
-                .Where(path => !string.IsNullOrEmpty(path) && !AssetDatabase.IsValidFolder(path))
-                .Distinct()
-                .OrderBy(path => path, StringComparer.Ordinal)
-                .ToArray();
-        }
-
-        /// <summary>
-        ///     アセットを出力対象に含めるか判定する。
-        /// </summary>
-        /// <returns> 強制包含の拡張子に一致するか、使用中アセットであればtrue。 </returns>
-        private static bool IsExportTarget(
-            string path,
-            HashSet<string> usedAssetPaths,
-            IReadOnlyList<string> forceIncludeExtensions)
-        {
-            bool isForceIncluded = HasForceIncludeExtension(path, forceIncludeExtensions);
-
-            // 通常のフォルダは出力対象にしない。
-            // .bundle等のフォルダ形式アセットは、IsValidFolderの結果に関わらず拡張子一致で残す。
-            if (!isForceIncluded && AssetDatabase.IsValidFolder(path))
-            {
-                return false;
-            }
-
-            return isForceIncluded || usedAssetPaths.Contains(path);
+            AssetStoreToolsPackagePipelineRunner.Export(plan);
         }
 
         /// <summary>
@@ -590,6 +205,54 @@ namespace SymphonyFrameWork.Editor
             }
 
             return false;
+        }
+
+        /// <summary> 旧来のフラグ指定で組み立てた計画に付ける名前。 </summary>
+        private const string LEGACY_PIPELINE_NAME = "Export Mode Options";
+
+        /// <summary>
+        ///     旧来のフラグ指定を、等価な手順の並びへ変換する。
+        /// </summary>
+        /// <remarks>
+        ///     並び順は3.5.0までの実行順と一致させている。
+        ///     絞り込みはPlan段階のため、Execute段階の手順より先に走る。
+        /// </remarks>
+        /// <param name="mode"> 個別出力と統合出力の指定。 </param>
+        /// <param name="createZip"> 出力後にZIP化するか。 </param>
+        /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
+        /// <returns> 指定に対応する手順の並び。 </returns>
+        private static List<AssetStoreToolsPackageStepStrategy> CreateStepsFromOptions(
+            PackageModeEnum mode,
+            bool createZip,
+            bool usedDependencies)
+        {
+            List<AssetStoreToolsPackageStepStrategy> steps = new();
+
+            if (usedDependencies)
+            {
+                steps.Add(new AssetStoreToolsUsedDependenciesStrategy());
+            }
+
+            if ((mode & PackageModeEnum.Singles) != 0)
+            {
+                steps.Add(new AssetStoreToolsSinglePackageStrategy());
+            }
+
+            // 非推奨のCombineは削除まで動作を維持する必要があるため、
+            // 廃止予定の警告をここでは抑止する。利用側の指定に対しては警告が出る。
+#pragma warning disable CS0618
+            if ((mode & PackageModeEnum.Combine) != 0)
+            {
+                steps.Add(new AssetStoreToolsCombinePackageStrategy());
+            }
+#pragma warning restore CS0618
+
+            if (createZip)
+            {
+                steps.Add(new AssetStoreToolsCreateZipStrategy());
+            }
+
+            return steps;
         }
     }
 }

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8df46f7ecc90e442be77e87ed7fb419
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCombinePackageStrategy.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCombinePackageStrategy.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     全ディレクトリを1つの<c>.unitypackage</c>へまとめて出力する手順。
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Execute段階の手順。
+    ///         <b>統合パッケージはディレクトリ単位で取り出せないため、差分インポートの単位にならない。</b>
+    ///         この手順だけで出力した場合、<c>PackageManifest.json</c>は作られない。
+    ///     </para>
+    ///     <para>
+    ///         上記の理由から既定テンプレート（<see cref="AssetStoreToolsPackagePipeline" />の
+    ///         テンプレート）には含めていない。統合パッケージが必要な場合だけ、
+    ///         パイプラインへ明示的に追加する。
+    ///     </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class AssetStoreToolsCombinePackageStrategy : AssetStoreToolsPackageStepStrategy
+    {
+        /// <inheritdoc />
+        public override string DisplayName => "Combine";
+
+        /// <inheritdoc />
+        protected internal override void Execute(AssetStoreToolsPackageExportContext context)
+        {
+            WarnIfNotDiffImportable(context);
+
+            try
+            {
+                string combinedName =
+                    $"AllPackages_{context.DateTime:yyyyMMdd_HHmmss}.unitypackage";
+
+                string[] exportFiles;
+                ExportPackageOptions options;
+
+                if (context.Plan.IsFiltered)
+                {
+                    // 空判定は出力時バージョンを加える前に行う。加えた後では常に非空になる。
+                    if (context.Plan.Entries.All(entry => entry.AssetPaths.Count == 0))
+                    {
+                        Debug.LogWarning("使用中アセットが存在しないため統合パッケージを作成しませんでした。");
+                        return;
+                    }
+
+                    exportFiles = context.Plan.Entries
+                        .SelectMany(AssetStoreToolsPackagePipelineRunner.BuildExportFiles)
+                        .Distinct()
+                        .ToArray();
+                    options = ExportPackageOptions.Default;
+                }
+                else
+                {
+                    exportFiles = context.Plan.Entries
+                        .Select(entry => entry.DirectoryPath)
+                        .ToArray();
+                    options = ExportPackageOptions.Recurse;
+                }
+
+                AssetDatabase.ExportPackage(
+                    exportFiles,
+                    Path.Combine(context.ExportLocalPath, combinedName),
+                    options
+                );
+
+                Debug.Log($"合成パッケージ作成: {combinedName}");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"合計パッケージの出力に失敗\n{e}");
+            }
+        }
+
+        /// <summary>
+        ///     個別出力を伴わない場合に、差分インポートの対象外であることを警告する。
+        /// </summary>
+        /// <param name="context"> 実行中の出力コンテキスト。 </param>
+        private static void WarnIfNotDiffImportable(AssetStoreToolsPackageExportContext context)
+        {
+            bool hasSingles = context.Plan.Steps
+                .Any(step => step is AssetStoreToolsSinglePackageStrategy);
+
+            if (hasSingles)
+            {
+                return;
+            }
+
+            Debug.LogWarning(
+                $"[{nameof(AssetStoreToolsCombinePackageStrategy)}]\n"
+                + "統合パッケージだけの出力は差分インポートの対象になりません。"
+                + "ディレクトリ単位で取り出せないためです。"
+                + $"\n差分インポートが必要な場合は、パイプラインへ"
+                + $"{nameof(AssetStoreToolsSinglePackageStrategy)}を追加してください。");
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCombinePackageStrategy.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCombinePackageStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d09f29c0261e43a4fa39c5bcdecf4ffb

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCreateZipStrategy.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCreateZipStrategy.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using UnityEngine;
+using CompressionLevel = System.IO.Compression.CompressionLevel;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     出力フォルダをZIP化する手順。
+    /// </summary>
+    /// <remarks>
+    ///     Execute段階の手順。
+    ///     <b>出力を行う手順より後ろへ置くこと。</b>先頭へ置くと空のフォルダを圧縮する。
+    ///     順序はフレームワークが並べ替えず、パイプラインの並びをそのまま実行する。
+    /// </remarks>
+    [Serializable]
+    public sealed class AssetStoreToolsCreateZipStrategy : AssetStoreToolsPackageStepStrategy
+    {
+        /// <inheritdoc />
+        public override string DisplayName => "Create ZIP";
+
+        /// <inheritdoc />
+        protected internal override void Execute(AssetStoreToolsPackageExportContext context)
+        {
+            try
+            {
+                string zipFullPath = Path.Combine(context.ExportRoot, $"{context.PackageName}.zip");
+
+                if (!Directory.Exists(context.ExportFullPath))
+                {
+                    Debug.LogError($"ZIP対象フォルダが存在しません: {context.ExportFullPath}");
+                    return;
+                }
+
+                if (File.Exists(zipFullPath))
+                {
+                    File.Delete(zipFullPath);
+                }
+
+                ZipFile.CreateFromDirectory(
+                    context.ExportFullPath,
+                    zipFullPath,
+                    CompressionLevel.Optimal,
+                    true
+                );
+
+                Debug.Log($"ZIP作成完了: {zipFullPath}");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"ZIP作成失敗\n{e}");
+            }
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCreateZipStrategy.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsCreateZipStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c8506fb4788c674e9864ad2bc86e00c

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageExportContext.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageExportContext.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     Execute段階の手順が共有する、出力先パスと確定済みの計画。
+    /// </summary>
+    /// <remarks>
+    ///     生成できるのは<see cref="AssetStoreToolsPackagePipelineRunner" />だけで、
+    ///     1回の出力につき1つだけ作られる。
+    /// </remarks>
+    public sealed class AssetStoreToolsPackageExportContext
+    {
+        /// <summary> 出力内容を確定した計画。 </summary>
+        public AssetStoreToolsPackagePlan Plan { get; }
+
+        /// <summary> 日時を含む出力パッケージ名。 </summary>
+        public string PackageName { get; }
+
+        /// <summary> パッケージ出力先の絶対ルートパス。 </summary>
+        public string ExportRoot { get; }
+
+        /// <summary> AssetDatabaseから扱えるパッケージ出力先パス。 </summary>
+        public string ExportLocalPath { get; }
+
+        /// <summary> 今回のパッケージ出力先となる絶対パス。 </summary>
+        public string ExportFullPath { get; }
+
+        /// <summary> パッケージ処理を開始した日時。 </summary>
+        public DateTime DateTime { get; }
+
+        /// <summary> 計画と出力先設定から、1回分の出力コンテキストを生成する。 </summary>
+        /// <param name="plan"> 出力内容を確定した計画。 </param>
+        /// <param name="basePackageName"> 出力フォルダ名の基本部分。 </param>
+        /// <param name="exportRoot"> 出力先フォルダのプロジェクト相対パス。 </param>
+        internal AssetStoreToolsPackageExportContext(
+            AssetStoreToolsPackagePlan plan,
+            string basePackageName,
+            string exportRoot)
+        {
+            Plan = plan;
+            DateTime = DateTime.Now;
+            PackageName = $"Export_{basePackageName}_{DateTime:yyyyMMdd_HHmmss}";
+
+            ExportRoot = Path.Combine(Application.dataPath, "..", exportRoot);
+            ExportLocalPath = Path.Combine(exportRoot, PackageName);
+            ExportFullPath = Path.Combine(ExportRoot, PackageName);
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageExportContext.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageExportContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 17aad71426373a1458729e18cfdaa397

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipeline.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipeline.cs
@@ -1,0 +1,56 @@
+﻿using SymphonyFrameWork.Attribute;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     Asset Store Tools Packagerが実行する手順の並びを保持するアセット。
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Project Settings > SymphonyFrameWork > Asset Store Tools Packager で
+    ///         このアセットを配列としてアサインすると、Packagerウィンドウの出力形式の選択肢になる。
+    ///         選択肢の表示名はアセット名。
+    ///     </para>
+    ///     <para>
+    ///         手順は<see cref="AssetStoreToolsPackageStepStrategy" />を継承して自作でき、
+    ///         サブクラスセレクターから選択できる。
+    ///     </para>
+    /// </remarks>
+    [CreateAssetMenu(
+        fileName = nameof(AssetStoreToolsPackagePipeline),
+        menuName = "SymphonyFrameWork/Asset Store Tools Package Pipeline")]
+    public sealed class AssetStoreToolsPackagePipeline : ScriptableObject
+    {
+        /// <summary> 実行する手順。 </summary>
+        public IReadOnlyList<AssetStoreToolsPackageStepStrategy> Steps => _steps;
+
+        [SerializeReference]
+        [SubclassSelector]
+        [Tooltip("実行する手順。Plan段階とExecute段階のそれぞれで、この順序どおりに実行される。")]
+        private List<AssetStoreToolsPackageStepStrategy> _steps = new();
+
+        /// <summary>
+        ///     既定テンプレートの手順を持つインスタンスを生成する。
+        /// </summary>
+        /// <remarks>
+        ///     <see cref="AssetStoreToolsCombinePackageStrategy" />は含めない。
+        ///     統合パッケージが差分インポートの単位にならないため、
+        ///     必要な利用者だけが自分でパイプラインへ追加する位置付けにしている。
+        /// </remarks>
+        /// <returns> Singles → Used Dependencies → Create ZIP を持つ未保存のインスタンス。 </returns>
+        internal static AssetStoreToolsPackagePipeline CreateTemplate()
+        {
+            var pipeline = CreateInstance<AssetStoreToolsPackagePipeline>();
+            pipeline._steps = new List<AssetStoreToolsPackageStepStrategy>
+            {
+                new AssetStoreToolsSinglePackageStrategy(),
+                new AssetStoreToolsUsedDependenciesStrategy(),
+                new AssetStoreToolsCreateZipStrategy(),
+            };
+
+            return pipeline;
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipeline.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipeline.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97908234244009d4596b8321c39d5bab

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipelineRunner.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipelineRunner.cs
@@ -1,0 +1,268 @@
+﻿using SymphonyFrameWork.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     パイプラインの手順を2段階で実行する。
+    /// </summary>
+    /// <remarks>
+    ///     Plan段階で計画を組み立て、確認を経てExecute段階で出力する。
+    ///     計画とコンテキストを生成できるのはこのクラスだけで、手順から新しい計画は作れない。
+    /// </remarks>
+    internal static class AssetStoreToolsPackagePipelineRunner
+    {
+        /// <summary>
+        ///     出力内容を確定した計画を組み立てる。この時点ではファイルを出力しない。
+        /// </summary>
+        /// <param name="directories"> 出力対象のディレクトリ。 </param>
+        /// <param name="steps"> 実行する手順。null要素は取り除かれる。 </param>
+        /// <param name="pipelineName"> 確認ウィンドウへ表示するパイプライン名。 </param>
+        /// <returns> 出力計画。対象が無い場合や設定を読み込めない場合はnull。 </returns>
+        internal static AssetStoreToolsPackagePlan CreatePlan(
+            string[] directories,
+            IReadOnlyList<AssetStoreToolsPackageStepStrategy> steps,
+            string pipelineName)
+        {
+            if (directories == null || directories.Length == 0)
+            {
+                Debug.LogWarning("パッケージ化するフォルダが存在しませんでした。");
+                return null;
+            }
+
+            AssetStoreToolsPackagerConfig config = AssetStoreToolsPackagerConfigStore.Load();
+            if (config == null)
+            {
+                Debug.LogError($"{LOG_PREFIX}\n設定を読み込めなかったためパッケージを出力しませんでした。");
+                return null;
+            }
+
+            // 読み込めない場合もリビジョン0として出力は続行する。
+            // 差分インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
+            AssetStoreToolsVersionLog versionLog = AssetStoreToolsVersionLogStore.Load();
+
+            List<AssetStoreToolsPackagePlanEntry> entries = new();
+            foreach (string dir in directories)
+            {
+                string name = Path.GetFileName(dir);
+
+                entries.Add(new AssetStoreToolsPackagePlanEntry(
+                    dir,
+                    name,
+                    versionLog?.GetVersion(name) ?? 0,
+                    CollectAssets(dir, config.ForceIncludeExtensions)));
+            }
+
+            var plan = new AssetStoreToolsPackagePlan(
+                pipelineName,
+                SelectValidSteps(steps),
+                entries,
+                config.ForceIncludeExtensions);
+
+            RunPlanSteps(plan);
+
+            return plan;
+        }
+
+        /// <summary>
+        ///     計画へ持ち込める手順だけを取り出す。
+        /// </summary>
+        /// <remarks>
+        ///     サブクラスセレクターは&lt;null&gt;を選べるため、null要素がそのまま配列へ残る。
+        /// </remarks>
+        /// <param name="steps"> パイプラインが保持する手順。 </param>
+        /// <returns> null要素を取り除いた手順。 </returns>
+        internal static AssetStoreToolsPackageStepStrategy[] SelectValidSteps(
+            IReadOnlyList<AssetStoreToolsPackageStepStrategy> steps)
+        {
+            return steps == null
+                ? Array.Empty<AssetStoreToolsPackageStepStrategy>()
+                : steps.Where(step => step != null).ToArray();
+        }
+
+        /// <summary>
+        ///     Plan段階の手順を並び順に実行する。
+        /// </summary>
+        /// <remarks>
+        ///     1つの手順の失敗で計画全体を捨てない。
+        ///     絞り込みが効かないまま出力されることは確認ウィンドウで判別できる。
+        /// </remarks>
+        /// <param name="plan"> 組み立て中の出力計画。 </param>
+        internal static void RunPlanSteps(AssetStoreToolsPackagePlan plan)
+        {
+            foreach (AssetStoreToolsPackageStepStrategy step in plan.Steps)
+            {
+                try
+                {
+                    step.Plan(plan);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{LOG_PREFIX}\n手順の計画に失敗しました: {step.DisplayName}\n{e}");
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Execute段階の手順を並び順に実行する。
+        /// </summary>
+        /// <remarks>
+        ///     1つの手順の失敗で残りの出力まで巻き添えにしない。
+        /// </remarks>
+        /// <param name="context"> 出力先と確定済みの計画を保持するコンテキスト。 </param>
+        internal static void RunExecuteSteps(AssetStoreToolsPackageExportContext context)
+        {
+            foreach (AssetStoreToolsPackageStepStrategy step in context.Plan.Steps)
+            {
+                try
+                {
+                    step.Execute(context);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{LOG_PREFIX}\n手順の実行に失敗しました: {step.DisplayName}\n{e}");
+                }
+            }
+        }
+
+        /// <summary>
+        ///     確定済みの計画に従ってパイプラインを実行する。
+        /// </summary>
+        /// <param name="plan"> 出力する計画。 </param>
+        internal static void Export(AssetStoreToolsPackagePlan plan)
+        {
+            if (plan == null || plan.Entries.Count == 0)
+            {
+                Debug.LogWarning("パッケージ化するフォルダが存在しませんでした。");
+                return;
+            }
+
+            var context = new AssetStoreToolsPackageExportContext(
+                plan,
+                PACKAGE_NAME,
+                AssetStoreToolsPackagerData.ExportedPackagesPath);
+
+            // 出力フォルダ作成
+            if (!Directory.Exists(context.ExportFullPath))
+            {
+                Directory.CreateDirectory(context.ExportFullPath);
+            }
+
+            // 出力時バージョンを先に書き、AssetDatabaseへ載せてからパッケージ化する。
+            // Refreshを省くと新規ファイルがAssetDatabaseに載らず、Recurseでも明示指定でも出力されない。
+            // すべての出力手順が前提にする準備のため、手順にはせずランナーが必ず実行する。
+            WriteExportedVersions(plan);
+            AssetDatabase.Refresh();
+
+            if (plan.Steps.Count == 0)
+            {
+                Debug.LogWarning(
+                    $"{LOG_PREFIX}\n手順が1つも設定されていないため、出力時バージョンの書き出しだけを行いました。");
+            }
+
+            RunExecuteSteps(context);
+
+            Debug.Log($"{LOG_PREFIX}\nパッケージを出力しました\npath : {context.ExportLocalPath}");
+        }
+
+        /// <summary>
+        ///     出力対象アセットへ出力時バージョンファイルのパスを加える。
+        /// </summary>
+        /// <remarks>
+        ///     絞り込みを行った経路では計画の一覧がそのままExportPackageの引数になるため、
+        ///     ここで加えないとバージョンファイルがパッケージへ含まれない。
+        ///     計画そのものへは加えない。加えると空のディレクトリを検出できなくなる。
+        /// </remarks>
+        /// <param name="entry"> 出力単位。 </param>
+        /// <returns> パスの昇順で並んだ出力対象アセットのパス。 </returns>
+        internal static string[] BuildExportFiles(AssetStoreToolsPackagePlanEntry entry)
+        {
+            return entry.AssetPaths
+                .Append(BuildExportedVersionPath(entry.DirectoryPath))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        /// <summary>
+        ///     指定ディレクトリから出力候補のアセットを収集する。
+        /// </summary>
+        /// <remarks>
+        ///     ファイルシステムではなくAssetDatabaseを走査する。
+        ///     .bundleや.frameworkはUnityが単一アセットとして扱うため、
+        ///     ファイル列挙では中身のファイルしか拾えず、ExportPackageへ渡しても出力されない。
+        /// </remarks>
+        /// <param name="dir"> 収集対象のディレクトリ。 </param>
+        /// <param name="forceIncludeExtensions"> 依存関係に関わらず含める拡張子の一覧。 </param>
+        /// <returns> パスの昇順で並んだ出力候補アセットのパス。通常のフォルダは含まない。 </returns>
+        internal static string[] CollectAssets(
+            string dir,
+            IReadOnlyList<string> forceIncludeExtensions)
+        {
+            return AssetDatabase.FindAssets(string.Empty, new[] { dir })
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(path => !string.IsNullOrEmpty(path))
+                .Distinct()
+                .Where(path => IsCollectTarget(path, forceIncludeExtensions))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private const string LOG_PREFIX = "[" + nameof(AssetStoreToolsPackager) + "]";
+
+        private const string PACKAGE_NAME = "AssetStoreToolsPackage";
+
+        /// <summary>
+        ///     絞り込み前の収集対象に含めるか判定する。
+        /// </summary>
+        /// <remarks>
+        ///     通常のフォルダは出力対象にしない。
+        ///     .bundle等のフォルダ形式アセットは、IsValidFolderの結果に関わらず拡張子一致で残す。
+        /// </remarks>
+        /// <param name="path"> 判定するアセットのパス。 </param>
+        /// <param name="forceIncludeExtensions"> 強制包含する拡張子の一覧。 </param>
+        /// <returns> 収集対象に含める場合はtrue。 </returns>
+        private static bool IsCollectTarget(
+            string path,
+            IReadOnlyList<string> forceIncludeExtensions)
+        {
+            if (AssetStoreToolsPackager.HasForceIncludeExtension(path, forceIncludeExtensions))
+            {
+                return true;
+            }
+
+            return !AssetDatabase.IsValidFolder(path);
+        }
+
+        /// <summary> ディレクトリ直下の出力時バージョンファイルのパスを組み立てる。 </summary>
+        /// <param name="directoryPath"> 出力単位となるディレクトリのパス。 </param>
+        /// <returns> スラッシュ区切りのアセットパス。 </returns>
+        private static string BuildExportedVersionPath(string directoryPath)
+            => directoryPath.Replace("\\", "/").TrimEnd('/')
+               + "/" + EditorSymphonyConstant.ASSET_STORE_TOOLS_EXPORTED_VERSION_FILE_NAME;
+
+        /// <summary>
+        ///     計画中の各ディレクトリへ出力時バージョンを書き出す。
+        /// </summary>
+        /// <remarks>
+        ///     書き込みに失敗しても出力は続行する。バージョンファイルの無いパッケージは
+        ///     インポート側で常に新規と判定されるだけで、既存の出力機能は損なわれない。
+        /// </remarks>
+        /// <param name="plan"> 出力する計画。 </param>
+        private static void WriteExportedVersions(AssetStoreToolsPackagePlan plan)
+        {
+            foreach (AssetStoreToolsPackagePlanEntry entry in plan.Entries)
+            {
+                AssetStoreToolsVersionLogStore.TryWriteExportedVersion(
+                    entry.DirectoryPath,
+                    entry.Name,
+                    entry.Version);
+            }
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipelineRunner.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackagePipelineRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 595b8afa25a1ae145a6cdc760c8bda8a

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageStepStrategy.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageStepStrategy.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     パッケージ出力の1手順を表す拡張点。
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         手順は<see cref="Plan" />段階と<see cref="Execute" />段階に分かれ、
+    ///         パイプライン全体で「全手順の<see cref="Plan" />」→「全手順の<see cref="Execute" />」の順に走る。
+    ///         各段階の中では<see cref="AssetStoreToolsPackagePipeline.Steps" />の順序どおりに実行される。
+    ///     </para>
+    ///     <para>
+    ///         2段階に分けるのは、出力前に確認ウィンドウで内容を提示するため。
+    ///         絞り込みが<see cref="Execute" />の中で起きると、提示した一覧と実物が食い違う。
+    ///     </para>
+    ///     <para>
+    ///         別アセンブリでこのクラスを継承する場合、
+    ///         <see cref="Plan" />と<see cref="Execute" />のオーバーライドは<c>protected</c>として宣言する。
+    ///         C#の規則により、別アセンブリからは<c>protected internal</c>のままでは宣言できない。
+    ///     </para>
+    /// </remarks>
+    [Serializable]
+    public abstract class AssetStoreToolsPackageStepStrategy
+    {
+        /// <summary> ウィンドウと確認ウィンドウへ表示する名前。 </summary>
+        public virtual string DisplayName => GetType().Name;
+
+        /// <summary>
+        ///     出力対象を絞り込む段階。既定では何もしない。
+        /// </summary>
+        /// <remarks>
+        ///     ファイルを書き出さないこと。この段階の結果が確認ウィンドウへ提示される。
+        /// </remarks>
+        /// <param name="plan"> 組み立て中の出力計画。 </param>
+        protected internal virtual void Plan(AssetStoreToolsPackagePlan plan)
+        {
+        }
+
+        /// <summary>
+        ///     出力を行う段階。既定では何もしない。
+        /// </summary>
+        /// <remarks>
+        ///     この段階で例外を投げても、ランナーが記録して次の手順へ進む。
+        /// </remarks>
+        /// <param name="context"> 出力先と確定済みの計画を保持するコンテキスト。 </param>
+        protected internal virtual void Execute(AssetStoreToolsPackageExportContext context)
+        {
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageStepStrategy.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsPackageStepStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6f953ed77f64374f96f004a8216b6f9

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsSinglePackageStrategy.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsSinglePackageStrategy.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     ディレクトリごとに<c>.unitypackage</c>を出力し、差分インポート用のマニフェストを書く手順。
+    /// </summary>
+    /// <remarks>
+    ///     Execute段階の手順。個別出力したパッケージだけが差分インポートの単位になる。
+    /// </remarks>
+    [Serializable]
+    public sealed class AssetStoreToolsSinglePackageStrategy : AssetStoreToolsPackageStepStrategy
+    {
+        /// <inheritdoc />
+        public override string DisplayName => "Singles";
+
+        /// <inheritdoc />
+        protected internal override void Execute(AssetStoreToolsPackageExportContext context)
+        {
+            foreach (AssetStoreToolsPackagePlanEntry entry in context.Plan.Entries)
+            {
+                ExportEntry(context, entry);
+            }
+
+            WriteManifest(context);
+        }
+
+        /// <summary> 出力単位1件分をパッケージ化する。 </summary>
+        /// <param name="context"> 出力先を保持するコンテキスト。 </param>
+        /// <param name="entry"> 出力する単位。 </param>
+        private static void ExportEntry(
+            AssetStoreToolsPackageExportContext context,
+            AssetStoreToolsPackagePlanEntry entry)
+        {
+            try
+            {
+                string[] exportFiles;
+                ExportPackageOptions options;
+
+                if (entry.IsFiltered)
+                {
+                    if (entry.AssetPaths.Count == 0)
+                    {
+                        Debug.LogWarning($"使用中アセットなし: {entry.DirectoryPath}");
+                        return;
+                    }
+
+                    // 出力時バージョンは計画に含めず、ここで加える。
+                    exportFiles = AssetStoreToolsPackagePipelineRunner.BuildExportFiles(entry);
+                    options = ExportPackageOptions.Default;
+                }
+                else
+                {
+                    // 丸ごと出力する経路。計画のAssetPathsは提示用で、出力はディレクトリ単位で行う。
+                    exportFiles = new[] { entry.DirectoryPath };
+                    options = ExportPackageOptions.Recurse;
+                }
+
+                AssetDatabase.ExportPackage(
+                    exportFiles,
+                    Path.Combine(context.ExportLocalPath, $"{entry.Name}.unitypackage"),
+                    options
+                );
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"パッケージの出力に失敗しました: {entry.DirectoryPath}\n{e}");
+            }
+        }
+
+        /// <summary>
+        ///     出力先フォルダへ、個別出力したパッケージ一覧のマニフェストを書き出す。
+        /// </summary>
+        /// <remarks>
+        ///     ZIPへ含めるため、ZIP化より前に書く必要がある。
+        ///     パイプラインの並び順で<see cref="AssetStoreToolsCreateZipStrategy" />より後ろに置くと、
+        ///     マニフェストがZIPへ含まれない。
+        /// </remarks>
+        /// <param name="context"> 出力先を保持するコンテキスト。 </param>
+        private static void WriteManifest(AssetStoreToolsPackageExportContext context)
+        {
+            var manifest = new AssetStoreToolsPackageManifest
+            {
+                ExportedAt = AssetStoreToolsVersionLog.CreateTimestamp(),
+                Packages = context.Plan.Entries
+                    .Select(entry => new AssetStoreToolsPackageManifestEntry
+                    {
+                        Name = entry.Name,
+                        Version = entry.Version,
+                        FileName = $"{entry.Name}.unitypackage",
+                    })
+                    .ToList(),
+            };
+
+            AssetStoreToolsVersionLogStore.TryWriteManifest(context.ExportFullPath, manifest);
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsSinglePackageStrategy.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsSinglePackageStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba8fefc1e77b9524a95d1c593a4cb286

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsUsedDependenciesStrategy.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsUsedDependenciesStrategy.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+
+namespace SymphonyFrameWork.Editor
+{
+    /// <summary>
+    ///     出力対象を、プロジェクト内で使用中のアセットと強制包含拡張子だけへ絞り込む手順。
+    /// </summary>
+    /// <remarks>
+    ///     Plan段階の手順。パイプラインのどこに置いてもExecute段階より先に走る。
+    /// </remarks>
+    [Serializable]
+    public sealed class AssetStoreToolsUsedDependenciesStrategy : AssetStoreToolsPackageStepStrategy
+    {
+        /// <inheritdoc />
+        public override string DisplayName => "Used Dependencies";
+
+        /// <inheritdoc />
+        protected internal override void Plan(AssetStoreToolsPackagePlan plan)
+        {
+            HashSet<string> usedAssetPaths =
+                CollectProjectUsedDependencies(AssetStoreToolsPackagerData.AssetStoreToolsPath);
+
+            foreach (AssetStoreToolsPackagePlanEntry entry in plan.Entries)
+            {
+                entry.FilterAssetPaths(
+                    path => IsUsedTarget(path, usedAssetPaths, plan.ForceIncludeExtensions));
+            }
+        }
+
+        /// <summary>
+        ///     アセットを出力対象として残すか判定する。
+        /// </summary>
+        /// <param name="path"> 判定するアセットのパス。 </param>
+        /// <param name="usedAssetPaths"> プロジェクト内で使用中のアセットのパス集合。 </param>
+        /// <param name="forceIncludeExtensions"> 依存関係に関わらず含める拡張子の一覧。 </param>
+        /// <returns> 強制包含の拡張子に一致するか、使用中アセットであればtrue。 </returns>
+        internal static bool IsUsedTarget(
+            string path,
+            HashSet<string> usedAssetPaths,
+            IReadOnlyList<string> forceIncludeExtensions)
+        {
+            if (AssetStoreToolsPackager.HasForceIncludeExtension(path, forceIncludeExtensions))
+            {
+                return true;
+            }
+
+            return usedAssetPaths != null && usedAssetPaths.Contains(path);
+        }
+
+        /// <summary>
+        ///     プロジェクト内の全アセットが依存している（＝使用している）アセットのパス一覧を取得する。
+        /// </summary>
+        /// <param name="excludedRootPath"> 依存元から除外するルートパス。 </param>
+        /// <returns> 使用中アセットのパス集合。 </returns>
+        private static HashSet<string> CollectProjectUsedDependencies(string excludedRootPath)
+        {
+            HashSet<string> usedPaths = new();
+
+            // プロジェクト内のすべての一般アセット（Assetsフォルダ以下）を検索
+            string[] allAssetGuids = AssetDatabase.FindAssets(string.Empty, new[] { "Assets" });
+
+            string normalizedExcludedRootPath = excludedRootPath
+                ?.Replace("\\", "/")
+                .TrimEnd('/');
+
+            foreach (string guid in allAssetGuids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+
+                // AssetStoreToolsは除外して依存関係を追う
+                if (!string.IsNullOrEmpty(normalizedExcludedRootPath)
+                    && (path.Equals(normalizedExcludedRootPath, StringComparison.Ordinal)
+                        || path.StartsWith(normalizedExcludedRootPath + "/", StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                // そのアセットが依存しているリソースをすべて取得
+                string[] dependencies = AssetDatabase.GetDependencies(path, recursive: true);
+
+                foreach (string dependency in dependencies)
+                {
+                    usedPaths.Add(dependency);
+                }
+            }
+
+            return usedPaths;
+        }
+    }
+}

--- a/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsUsedDependenciesStrategy.cs.meta
+++ b/Editor/Generator/AssetStoreToolsPackager/Pipeline/AssetStoreToolsUsedDependenciesStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52aeaf4bef7ab464fa4d6c0d8c1d0c8b

--- a/Tests/Editor/AssetStoreToolsPackagePipelineTests.cs
+++ b/Tests/Editor/AssetStoreToolsPackagePipelineTests.cs
@@ -1,0 +1,248 @@
+﻿using NUnit.Framework;
+
+using SymphonyFrameWork.Editor;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace SymphonyFrameWork.Tests
+{
+    /// <summary> パッケージ出力パイプラインの絞り込み、テンプレート、手順の実行を検証する。 </summary>
+    public sealed class AssetStoreToolsPackagePipelineTests
+    {
+        /// <summary> 述語に合わないパスが出力対象から外れる。 </summary>
+        [Test]
+        public void FilterAssetPaths_Predicate_KeepsOnlyMatching()
+        {
+            AssetStoreToolsPackagePlanEntry entry = CreateEntry(
+                "Assets/AssetStoreTools/Cri/Cri.asmdef",
+                "Assets/AssetStoreTools/Cri/Icon.png",
+                "Assets/AssetStoreTools/Cri/Runtime.cs");
+
+            entry.FilterAssetPaths(path => path.EndsWith(".cs", StringComparison.Ordinal));
+
+            CollectionAssert.AreEqual(
+                new[] { "Assets/AssetStoreTools/Cri/Runtime.cs" },
+                entry.AssetPaths);
+        }
+
+        /// <summary> 絞り込みでは出力対象が増えない。 </summary>
+        [Test]
+        public void FilterAssetPaths_AlwaysTruePredicate_DoesNotAddPaths()
+        {
+            AssetStoreToolsPackagePlanEntry entry = CreateEntry(
+                "Assets/AssetStoreTools/Cri/Icon.png",
+                "Assets/AssetStoreTools/Cri/Runtime.cs");
+            int initialCount = entry.AssetPaths.Count;
+
+            entry.FilterAssetPaths(_ => true);
+            entry.FilterAssetPaths(_ => true);
+
+            Assert.That(entry.AssetPaths.Count, Is.EqualTo(initialCount));
+        }
+
+        /// <summary> 絞り込みを行うとIsFilteredが立つ。 </summary>
+        [Test]
+        public void FilterAssetPaths_AfterCall_SetsIsFiltered()
+        {
+            AssetStoreToolsPackagePlanEntry entry = CreateEntry("Assets/AssetStoreTools/Cri/Runtime.cs");
+
+            Assert.That(entry.IsFiltered, Is.False);
+
+            entry.FilterAssetPaths(_ => true);
+
+            Assert.That(entry.IsFiltered, Is.True);
+        }
+
+        /// <summary> 述語がnullなら例外を投げる。 </summary>
+        [Test]
+        public void FilterAssetPaths_NullPredicate_Throws()
+        {
+            AssetStoreToolsPackagePlanEntry entry = CreateEntry("Assets/AssetStoreTools/Cri/Runtime.cs");
+
+            Assert.That(() => entry.FilterAssetPaths(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary> 1件でも絞り込まれていれば計画全体が絞り込み済みとして扱われる。 </summary>
+        [Test]
+        public void IsFiltered_OneEntryFiltered_IsTrue()
+        {
+            AssetStoreToolsPackagePlanEntry filtered = CreateEntry("Assets/AssetStoreTools/A/A.cs");
+            AssetStoreToolsPackagePlanEntry untouched = CreateEntry("Assets/AssetStoreTools/B/B.cs");
+            AssetStoreToolsPackagePlan plan = CreatePlan(filtered, untouched);
+
+            Assert.That(plan.IsFiltered, Is.False);
+
+            filtered.FilterAssetPaths(_ => true);
+
+            Assert.That(plan.IsFiltered, Is.True);
+        }
+
+        /// <summary> 使用中でなくても強制包含拡張子のアセットは残る。 </summary>
+        [Test]
+        public void IsUsedTarget_ForceIncludedExtension_IsTrueWithoutUsage()
+        {
+            bool result = AssetStoreToolsUsedDependenciesStrategy.IsUsedTarget(
+                "Assets/AssetStoreTools/Cri/Cri.asmdef",
+                new HashSet<string>(),
+                new[] { ".asmdef" });
+
+            Assert.That(result, Is.True);
+        }
+
+        /// <summary> 使用中アセットは強制包含拡張子でなくても残る。 </summary>
+        [Test]
+        public void IsUsedTarget_UsedAsset_IsTrue()
+        {
+            bool result = AssetStoreToolsUsedDependenciesStrategy.IsUsedTarget(
+                "Assets/AssetStoreTools/Cri/Icon.png",
+                new HashSet<string> { "Assets/AssetStoreTools/Cri/Icon.png" },
+                new[] { ".asmdef" });
+
+            Assert.That(result, Is.True);
+        }
+
+        /// <summary> 使用中でも強制包含でもないアセットは外れる。 </summary>
+        [Test]
+        public void IsUsedTarget_UnusedAsset_IsFalse()
+        {
+            bool result = AssetStoreToolsUsedDependenciesStrategy.IsUsedTarget(
+                "Assets/AssetStoreTools/Cri/Icon.png",
+                new HashSet<string>(),
+                new[] { ".asmdef" });
+
+            Assert.That(result, Is.False);
+        }
+
+        /// <summary> テンプレートはSingles、Used Dependencies、Create ZIPをこの順で持つ。 </summary>
+        [Test]
+        public void CreateTemplate_ContainsSinglesUsedDependenciesAndZipInOrder()
+        {
+            AssetStoreToolsPackagePipeline pipeline = AssetStoreToolsPackagePipeline.CreateTemplate();
+
+            try
+            {
+                Assert.That(pipeline.Steps.Count, Is.EqualTo(3));
+                Assert.That(pipeline.Steps[0], Is.InstanceOf<AssetStoreToolsSinglePackageStrategy>());
+                Assert.That(pipeline.Steps[1], Is.InstanceOf<AssetStoreToolsUsedDependenciesStrategy>());
+                Assert.That(pipeline.Steps[2], Is.InstanceOf<AssetStoreToolsCreateZipStrategy>());
+            }
+            finally
+            {
+                ScriptableObject.DestroyImmediate(pipeline);
+            }
+        }
+
+        /// <summary> テンプレートには統合パッケージ出力を含めない。 </summary>
+        [Test]
+        public void CreateTemplate_DoesNotContainCombineStrategy()
+        {
+            AssetStoreToolsPackagePipeline pipeline = AssetStoreToolsPackagePipeline.CreateTemplate();
+
+            try
+            {
+                Assert.That(
+                    pipeline.Steps.Any(step => step is AssetStoreToolsCombinePackageStrategy),
+                    Is.False);
+            }
+            finally
+            {
+                ScriptableObject.DestroyImmediate(pipeline);
+            }
+        }
+
+        /// <summary> サブクラスセレクターで未選択のままのnull要素は計画へ持ち込まれない。 </summary>
+        [Test]
+        public void SelectValidSteps_NullElements_AreRemoved()
+        {
+            var steps = new List<AssetStoreToolsPackageStepStrategy>
+            {
+                null,
+                new AssetStoreToolsCreateZipStrategy(),
+                null,
+            };
+
+            AssetStoreToolsPackageStepStrategy[] result =
+                AssetStoreToolsPackagePipelineRunner.SelectValidSteps(steps);
+
+            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result[0], Is.InstanceOf<AssetStoreToolsCreateZipStrategy>());
+        }
+
+        /// <summary> 手順がnullでも実行時に落ちない。 </summary>
+        [Test]
+        public void RunPlanSteps_NullSteps_DoesNotThrow()
+        {
+            AssetStoreToolsPackagePlan plan = CreatePlan(
+                AssetStoreToolsPackagePipelineRunner.SelectValidSteps(null),
+                CreateEntry("Assets/AssetStoreTools/A/A.cs"));
+
+            Assert.That(() => AssetStoreToolsPackagePipelineRunner.RunPlanSteps(plan), Throws.Nothing);
+        }
+
+        /// <summary> 1つの手順が例外を投げても後続の手順は実行される。 </summary>
+        [Test]
+        public void RunPlanSteps_StepThrows_ContinuesToNextStep()
+        {
+            var throwing = new ThrowingPlanStepStub();
+            var following = new RecordingPlanStepStub();
+            AssetStoreToolsPackagePlan plan = CreatePlan(
+                new AssetStoreToolsPackageStepStrategy[] { throwing, following },
+                CreateEntry("Assets/AssetStoreTools/A/A.cs"));
+
+            // 失敗した手順はLogErrorで記録される。期待するログとして消費する。
+            LogAssert.Expect(LogType.Error, new Regex("手順の計画に失敗しました"));
+
+            AssetStoreToolsPackagePipelineRunner.RunPlanSteps(plan);
+
+            Assert.That(following.IsPlanned, Is.True);
+        }
+
+        /// <summary> DisplayNameを持たない手順は型名を表示名にする。 </summary>
+        [Test]
+        public void DisplayName_NotOverridden_IsTypeName()
+        {
+            var step = new RecordingPlanStepStub();
+
+            Assert.That(step.DisplayName, Is.EqualTo(nameof(RecordingPlanStepStub)));
+        }
+
+        /// <summary> Plan段階で必ず例外を投げるテスト用の手順。 </summary>
+        private sealed class ThrowingPlanStepStub : AssetStoreToolsPackageStepStrategy
+        {
+            /// <inheritdoc />
+            protected internal override void Plan(AssetStoreToolsPackagePlan plan)
+                => throw new InvalidOperationException("テスト用の失敗");
+        }
+
+        /// <summary> Plan段階が呼ばれたことを記録するテスト用の手順。 </summary>
+        private sealed class RecordingPlanStepStub : AssetStoreToolsPackageStepStrategy
+        {
+            /// <summary> Plan段階が呼ばれたかを示す。 </summary>
+            public bool IsPlanned { get; private set; }
+
+            /// <inheritdoc />
+            protected internal override void Plan(AssetStoreToolsPackagePlan plan) => IsPlanned = true;
+        }
+
+        /// <summary> 指定したアセットパスを持つ出力単位を生成する。 </summary>
+        private static AssetStoreToolsPackagePlanEntry CreateEntry(params string[] assetPaths)
+            => new("Assets/AssetStoreTools/Cri", "Cri", 0, assetPaths);
+
+        /// <summary> 手順を持たない計画を生成する。 </summary>
+        private static AssetStoreToolsPackagePlan CreatePlan(
+            params AssetStoreToolsPackagePlanEntry[] entries)
+            => CreatePlan(Array.Empty<AssetStoreToolsPackageStepStrategy>(), entries);
+
+        /// <summary> 指定した手順と出力単位を持つ計画を生成する。 </summary>
+        private static AssetStoreToolsPackagePlan CreatePlan(
+            IReadOnlyList<AssetStoreToolsPackageStepStrategy> steps,
+            params AssetStoreToolsPackagePlanEntry[] entries)
+            => new("Test", steps, entries, new[] { ".asmdef" });
+    }
+}

--- a/Tests/Editor/AssetStoreToolsPackagePipelineTests.cs.meta
+++ b/Tests/Editor/AssetStoreToolsPackagePipelineTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be7842123167ec540974773fef3f5f07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Issue: #124

Asset Store Tools Packager の出力手順を、順序付きの Strategy 列（パイプライン）として組み替えられるようにする改修の **Round 1（基盤）** です。

設計書: `Documentation/Designs/AssetStoreToolsPackagePipeline.md`（ワークスペース側）

## この Round の範囲

**ウィンドウの操作と出力結果は 3.5.0 と同じです。内部の実行経路だけをパイプラインへ移し、公開APIは追加だけです。**

- 拡張点 `AssetStoreToolsPackageStepStrategy`（`Plan` / `Execute` の2段階）と既定の手順4種
- 手順の並びを持つ `AssetStoreToolsPackagePipeline`（`ScriptableObject`、`[SerializeReference]` + サブクラスセレクター）
- `AssetStoreToolsPackagePipelineRunner`
- `AssetStoreToolsPackagePlan` / `PlanEntry` の公開化と `FilterAssetPaths`
- `AssetStoreToolsPackageExportContext` の追加、`AssetStoreToolsPackageContext` の非推奨化
- 旧 `Export(string[], PackageModeEnum, bool, bool)` はフラグから手順を組み立てて委譲（動作は不変）

含まないもの（Round 2 / 3.7.0 予定）: Project Settings への配列アサイン、ウィンドウの `Export Mode` のポップアップ化、旧APIの `[Obsolete]` 化。

## Combine の扱い

**統合パッケージ出力は `AssetStoreToolsCombinePackageStrategy` として残します。** 「差分インポートの単位にならない」という 3.4.0 の判断は変えず、**既定テンプレートには含めない**位置付けにしています（Issue #124 のコメント）。この Strategy に `[Obsolete]` は付けていません。`PackageModeEnum.Combine` の削除予定は `Documentation~/Deprecations.md` で移行先を更新しました。

## 2段階実行にした理由

- 出力前に確認ウィンドウで内容を提示するため。絞り込みが `Execute` の中で起きると、提示した一覧と実物が食い違う
- Issue が指定したテンプレート順（Single → Used Dependence → Create Zip）を、そのまま正しく動く順序にするため

## 検証

- `uloop-compile`: エラー0 / `Assets/SymphonyFrameWork/` 由来の警告0
- EditMode テスト: 282件全数成功（うち新規14件）。2回連続で `Success=true` / `Failed=0` / `Skipped=0`
- **3.5.0 の出力との回帰比較**: `Singles + Used Dependencies + ZIP` と `Singles` のみの2通りで出力し、`.unitypackage` の同梱パス一覧が 3.5.0 の出力と一致することを確認（差分は、比較の間に作業ツリーへ追加されたアセット分のみ）
- パイプライン経由の出力、`<null>` 要素のスキップ、Combine 単独時の警告を実機で確認
