### PR TITLE
[update]Packagerの出力形式をパイプライン選択へ差し替え

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [3.7.0] - 2026-08-05
+Packager ウィンドウの出力形式を、3.6.0 で追加したパイプラインから選ぶ形にしました。**固定の3オプション（`Export Mode` / `Create ZIP File` / `Used Dependencies`）は無くなります。**
+
+### Add
+
+- **Project Settings で出力パイプラインを配列としてアサインできるようにしました。** `Project Settings > SymphonyFrameWork > Asset Store Tools Packager` の `Export Pipelines` です。保存先は `ProjectSettings/Packages/symphonyframework/AssetStoreToolsPackagerData.asset` で、プロジェクト共有です。
+
+  `Create Default Pipeline` を押すと、`Singles → Used Dependencies → Create ZIP` のテンプレートを `Assets/Editor/SymphonyFrameWork/Configs/` へ生成してアサインします。**同名のアセットがある場合は上書きせず別名で作ります。** 利用側が手を入れたパイプラインを、ボタンの誤操作で失わせないためです。
+
+  **Framework の起動時に自動生成はしません。** 利用側のリポジトリへ意図しないアセットを増やさないためで、Runtime の設定アセットが自動生成されるのは Framework の動作に必須だからです。パイプラインは「使う人が構成するもの」です。
+
+- **`AssetStoreToolsPackagerData.Pipelines` と `SetPipelines` を追加しました。**
+
+### Change
+
+- **Packager ウィンドウの `Export Mode` を、パイプラインを選ぶポップアップ `Export Pipeline` へ変えました。** 選択肢の表示名はアセット名です。`Create ZIP File` と `Used Dependencies` のトグルは、パイプラインの手順として表現されるため削除しました。
+
+  **パイプラインが1つもアサインされていない場合は、案内を表示して Export ボタンを出しません。** `Open Project Settings` ボタンから設定画面へ移動できます。
+
+  **移行方法**: `Project Settings > SymphonyFrameWork > Asset Store Tools Packager` で `Create Default Pipeline` を1度押してください。3.5.0 までの `Singles` + `Used Dependencies` + `Create ZIP File` と同じ内容です。ZIP や絞り込みが不要なら、生成されたアセットの `Steps` から該当の手順を外します。
+
+  Export タブへ切り替えたとき、パイプラインの一覧を読み直します。ウィンドウを開いたまま Project Settings を変更することがあるためです。
+
+### Deprecated
+
+- **`AssetStoreToolsPackager.PackageModeEnum` を非推奨にしました。** `Combine` を除くと `Singles` と `Nothing` しか残らず、enum として意味を失うためです。**次のメジャー更新で enum ごと削除します。**
+
+  **移行方法**: `AssetStoreToolsPackagePipeline` を使用してください。`Singles` は `AssetStoreToolsSinglePackageStrategy`、`Combine` は `AssetStoreToolsCombinePackageStrategy` に対応します。
+
+- **`AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` を非推奨にしました。**
+
+  **移行方法**: `Export(string[], AssetStoreToolsPackagePipeline)` を使用してください。フラグと手順の対応は次のとおりです。
+
+  | 旧 | 新 |
+  | --- | --- |
+  | `mode` に `Singles` | `AssetStoreToolsSinglePackageStrategy` |
+  | `mode` に `Combine` | `AssetStoreToolsCombinePackageStrategy` |
+  | `usedDependencies: true` | `AssetStoreToolsUsedDependenciesStrategy` |
+  | `createZip: true` | `AssetStoreToolsCreateZipStrategy` |
+
+  **統合パッケージ出力は機能として残ります。** 非推奨にするのは enum の選択肢であって、統合パッケージそのものではありません。差分インポートの単位にならないため既定テンプレートには含めていませんが、必要な場合はパイプラインへ `AssetStoreToolsCombinePackageStrategy` を追加してください。
+
 ## [3.6.0] - 2026-08-05
 Asset Store Tools Packager の出力手順を、順序付きの Strategy 列（パイプライン）として組み替えられるようにしました。**ウィンドウの操作と出力結果は 3.5.0 と同じで、公開APIは追加だけです。**
 

--- a/Documentation~/Deprecations.md
+++ b/Documentation~/Deprecations.md
@@ -25,6 +25,8 @@ CHANGELOGだけでは、非推奨化した版まで遡らないと一覧でき�
 | `SymphonyTween.TweeningCurve<T>(...)` | `Runtime/Utility/SymphonyTween.cs` | `SymphonyTween.Tweening` | 記録なし | **未定** | 同上 |
 | `EditorSymphonyConstant.ASSET_STORE_TOOLS_IGNORE_FILE` | `Core/Editor/EditorSymphonyConstant.cs` | `EditorSymphonyConstant.ASSET_STORE_TOOLS_CONFIG_FILE_NAME` | 3.1.0 | 次のメジャー更新 | 削除時は `AssetStoreToolsPackagerConfigStore` の `ignore.txt` 移行処理（`IGNORE_FILE_NAME`、`ReadIgnoreFile`、`CreateConfigFile` の移行分岐）も一緒に削除する |
 | `AssetStoreToolsPackager.PackageModeEnum.Combine` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `AssetStoreToolsCombinePackageStrategy` | 3.4.0 | 次のメジャー更新 | **enum の選択肢としては消すが、統合パッケージ出力そのものは Strategy として残す。** 下記「Combineの削除手順」を参照 |
+| `AssetStoreToolsPackager.PackageModeEnum` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `AssetStoreToolsPackagePipeline` | 3.7.0 | 次のメジャー更新 | `Combine` を除くと `Singles` と `Nothing` しか残らず、enum として意味を失う。下記「Combineの削除手順」を参照 |
+| `AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs` | `Export(string[], AssetStoreToolsPackagePipeline)` | 3.7.0 | 次のメジャー更新 | `PackageModeEnum` と同時に削除する。3.7.0 以降フレームワーク内部では使用していない |
 | `AssetStoreToolsPackageContext` | `Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageContext.cs` | `AssetStoreToolsPackageExportContext` | 3.6.0 | 次のメジャー更新 | `ref struct` はフィールドへ保持できず、パイプラインの拡張点へ渡せない。3.6.0 以降フレームワーク内部では使用していない |
 
 ### Combineの削除手順
@@ -37,11 +39,11 @@ CHANGELOGだけでは、非推奨化した版まで遡らないと一覧でき�
 | --- | --- |
 | `AssetStoreToolsPackager.PackageModeEnum` | 削除する |
 | `AssetStoreToolsPackager.Export(string[], PackageModeEnum, bool, bool)` | 削除する。代替は `Export(string[], AssetStoreToolsPackagePipeline)`（3.6.0 で追加済み） |
-| `AssetStoreToolsPackager.CreatePlan(string[], PackageModeEnum, bool, bool)` | 削除する |
 | `AssetStoreToolsPackager.CreateStepsFromOptions` と `LEGACY_PIPELINE_NAME` | 削除する |
 | `AssetStoreToolsPackager` 内の `#pragma warning disable CS0618` | 抑止ごと削除する |
-| `AssetStoreToolsPackageWindow` | `Export Mode` の `EnumFlagsField` と `DrawCombineDeprecationHelp` を削除する（3.7.0 でパイプラインのポップアップへ置き換え予定） |
 | ワークスペースの `Documentation/DesignPhilosophy.md` | enum 命名の実例から `PackageModeEnum` を外す |
+
+`AssetStoreToolsPackageWindow` は 3.7.0 でパイプラインのポップアップへ置き換え済みのため、削除時に触る必要はありません。
 
 **旧シグネチャを `[Obsolete]` のシムとして残せません。** `PackageModeEnum` 自体が消えるため、旧シグネチャは型として成立しないためです。メジャー更新で直接削除し、CHANGELOG の `### Breaking` へ移行方法を明記します。
 

--- a/Documentation~/EditorTools.md
+++ b/Documentation~/EditorTools.md
@@ -124,10 +124,18 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 | --- | --- | --- |
 | Asset Store Tools Path | パッケージ化の対象となるフォルダ。既定は `Assets/AssetStoreTools` | `ProjectSettings/Packages/symphonyframework/AssetStoreToolsPackagerData.asset` |
 | Exported Packages Path | 出力先フォルダ。既定は `ExportedPackages` | 同上 |
+| Export Pipelines | Packagerウィンドウで選べる出力パイプライン | 同上 |
 | Ignored Directories | パッケージ対象から除外するフォルダ名 | `<Asset Store Tools Path>/PackagerConfig.json` |
 | Force Include Extensions | 依存関係に載らなくても必ず含める拡張子 | 同上 |
 
-**設定の分担**: 「どこにあるか」（パス）がProject Settings、「何を詰めるか」（除外・強制包含）が `PackagerConfig.json` です。`PackagerConfig.json` は `Assets/` 配下にあるため、利用側のリポジトリで版管理し、手で編集できます。
+**設定の分担**: 「どこにあるか」（パス）と「どう出すか」（パイプライン）がProject Settings、「何を詰めるか」（除外・強制包含）が `PackagerConfig.json` です。`PackagerConfig.json` は `Assets/` 配下にあるため、利用側のリポジトリで版管理し、手で編集できます。
+
+**Export Pipelines**:
+
+- `Create Default Pipeline` を押すと、`Singles → Used Dependencies → Create ZIP` のテンプレートを `Assets/Editor/SymphonyFrameWork/Configs/` へ生成してアサインします。**同名のアセットがある場合は上書きせず別名で作ります。**
+- `Add` で空の要素を足し、既存のパイプラインアセットをアサインできます。
+- **パイプラインは自動生成しません。** 利用側のリポジトリへ意図しないアセットを増やさないためで、Runtimeの設定アセットが自動生成されるのは Framework の動作に必須だからです。パイプラインは「使う人が構成するもの」です。
+- パス項目と同じく、**変更した時点で保存します。** `PackagerConfig.json` のような `Save` / `Reload` はありません。
 
 **注意点**:
 
@@ -149,27 +157,25 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 **操作**:
 
 1. 出力するフォルダをチェックボックスで選ぶ。`PackagerConfig.json` の `Ignored Directories` に入っているフォルダは `(Ignored)` と表示され、選択できません
-2. 出力形式を選ぶ
-
-   | 項目 | 内容 |
-   | --- | --- |
-   | Export Mode `Singles` | 選んだフォルダを個別の `.unitypackage` として出力する |
-   | Export Mode `Combine` | **廃止予定。** 選んだフォルダを1つの `.unitypackage` にまとめて出力する。差分インポートの対象にならない（→[非推奨APIと削除予定](./Deprecations.md)） |
-   | Create ZIP File | 出力フォルダ全体をZIP化する |
-   | Used Dependencies | プロジェクト内で実際に使用しているアセットと、強制包含拡張子だけに絞る |
-
-3. `Export Selected Directories` を押すと、**出力せずに確認ウィンドウが開きます。** パッケージへ含まれるアセットが階層表示されます
+2. `Export Pipeline` で出力手順を選ぶ。選択肢は Project Settings の `Export Pipelines` にアサインしたアセットで、表示名はアセット名です
+3. `Export Selected Directories` を押すと、**出力せずに確認ウィンドウが開きます。** パイプライン名、手順の並び、パッケージへ含まれるアセットの階層が表示されます
 4. `Export` で実行、`Cancel` で中止
 
 **出力先**: `<Exported Packages Path>/Export_AssetStoreToolsPackage_<日時>/`
+
+**注意点**:
+
+- **パイプラインが1つもアサインされていない場合、Export ボタンは表示されません。** `Open Project Settings` から設定画面へ移動し、`Create Default Pipeline` を押してください。
+- Export タブへ切り替えたとき、パイプラインの一覧を読み直します。ウィンドウを開いたまま Project Settings を変更することがあるためです。反映されない場合は `Refresh` を押してください。
+- **3.6.0 までの `Export Mode` / `Create ZIP File` / `Used Dependencies` は 3.7.0 で無くなりました。** 同じ内容は `Create Default Pipeline` が生成するテンプレートで表現されます（→[非推奨APIと削除予定](./Deprecations.md)）。
 
 ### 出力手順のパイプライン
 
 3.6.0 から、出力手順を順序付きの Strategy 列として組み替えられます。
 
-**入口**: `Assets > Create > SymphonyFrameWork > Asset Store Tools Package Pipeline`
+**入口**: `Assets > Create > SymphonyFrameWork > Asset Store Tools Package Pipeline`、または `Project Settings > SymphonyFrameWork > Asset Store Tools Packager` の `Create Default Pipeline`
 
-作成したアセットの `Steps` へ、サブクラスセレクターで手順を並べます。
+作成したアセットの `Steps` へ、サブクラスセレクターで手順を並べます。ウィンドウから選べるようにするには、Project Settings の `Export Pipelines` へアサインします。
 
 | 手順 | 段階 | 役割 |
 | --- | --- | --- |
@@ -185,7 +191,7 @@ Packagerが使う入出力パスと、パッケージへ何を詰めるかの設
 - **`Execute` 段階の順序は利用者の責任です。** `AssetStoreToolsCreateZipStrategy` を出力より前へ置くと、空のフォルダを圧縮します。フレームワークは並べ替えません。確認ウィンドウが並び順をそのまま表示します。
 - **`AssetStoreToolsCombinePackageStrategy` は差分インポートの対象になりません。** ディレクトリ単位で取り出せないためです。この手順だけのパイプラインでは `PackageManifest.json` が作られず、実行時に警告が出ます。
 - **1つの手順が例外を投げても、記録して次の手順へ進みます。** 自作手順の失敗でフレームワーク側の出力まで止めないためです。
-- **3.6.0 時点では、Export タブの操作は上の固定オプションのままです。** ウィンドウからパイプラインを選べるようになるのは 3.7.0 の予定です。コードから使う場合は `AssetStoreToolsPackager.Export(string[], AssetStoreToolsPackagePipeline)` を呼びます。
+- コードから実行する場合は `AssetStoreToolsPackager.Export(string[], AssetStoreToolsPackagePipeline)` を呼びます。Project Settings へのアサインは不要です。
 
 **自作の手順を追加する**: `AssetStoreToolsPackageStepStrategy` を継承し、`[Serializable]` を付けます。置き場は `SymphonyFrameWork.Editor` を参照する Editor 用 asmdef です。
 

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageWindow.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackageWindow.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 
 using SymphonyFrameWork.Core;
+using SymphonyFrameWork.Editor.SettingProvider;
 
 using UnityEditor;
 using UnityEngine;
@@ -66,9 +67,10 @@ namespace SymphonyFrameWork.Editor
 
         private List<DirectoryItem> _directoryItems = new();
         private Vector2 _scrollPosition;
-        private PackageModeEnum _packageMode = PackageModeEnum.Singles;
-        private bool _createZip = false;
-        private bool _usedDependencies = false;
+
+        private List<AssetStoreToolsPackagePipeline> _pipelines = new();
+        private string[] _pipelineLabels = Array.Empty<string>();
+        private int _selectedPipelineIndex;
 
         private PackagerTabEnum _tab = PackagerTabEnum.Export;
         private string[] _exportDirectories = Array.Empty<string>();
@@ -78,10 +80,11 @@ namespace SymphonyFrameWork.Editor
         private Vector2 _importScrollPosition;
         private bool _hasManifest;
 
-        /// <summary> ウィンドウ有効化時に出力対象ディレクトリ一覧を読み込む。 </summary>
+        /// <summary> ウィンドウ有効化時に出力対象ディレクトリとパイプラインを読み込む。 </summary>
         private void OnEnable()
         {
             RefreshDirectories();
+            RefreshPipelines();
         }
 
         /// <summary> タブを描画し、選択中のタブの内容へ委譲する。 </summary>
@@ -93,11 +96,20 @@ namespace SymphonyFrameWork.Editor
             PackagerTabEnum previousTab = _tab;
             _tab = (PackagerTabEnum)GUILayout.Toolbar((int)_tab, TAB_LABELS);
 
-            // Importタブへ入った時点で最新の状態を読み込む。
-            // 別プロジェクトで出力した直後に開くことがあるため、表示のたびに読み直す。
-            if (_tab != previousTab && _tab == PackagerTabEnum.Import)
+            // タブへ入った時点で最新の状態を読み込む。
+            // Importは別プロジェクトで出力した直後に開くことがあり、
+            // ExportはProject Settingsのパイプライン配列がウィンドウを開いたまま変わり得るため。
+            if (_tab != previousTab)
             {
-                RefreshImportCandidates();
+                switch (_tab)
+                {
+                    case PackagerTabEnum.Export:
+                        RefreshPipelines();
+                        break;
+                    case PackagerTabEnum.Import:
+                        RefreshImportCandidates();
+                        break;
+                }
             }
 
             EditorGUILayout.Space();
@@ -119,6 +131,7 @@ namespace SymphonyFrameWork.Editor
             if (GUILayout.Button("Refresh", GUILayout.Width(100)))
             {
                 RefreshDirectories();
+                RefreshPipelines();
             }
 
             EditorGUILayout.Space();
@@ -149,20 +162,15 @@ namespace SymphonyFrameWork.Editor
             EditorGUILayout.EndScrollView();
 
             EditorGUILayout.Space();
-            _packageMode = (PackageModeEnum)EditorGUILayout.EnumFlagsField("Export Mode", _packageMode);
-            DrawCombineDeprecationHelp();
-            _createZip = EditorGUILayout.ToggleLeft("Create ZIP File", _createZip);
-            _usedDependencies = EditorGUILayout.ToggleLeft("Used Dependencies", _usedDependencies);
+
+            if (!DrawPipelineSelection())
+            {
+                return;
+            }
 
             // エクスポートボタン。
             using (new EditorGUI.DisabledGroupScope(_directoryItems.All(d => !d.IsSelected)))
             {
-                if (_packageMode == PackageModeEnum.Nothing)
-                {
-                    GUILayout.TextField("Noting mode is invalid");
-                    return;
-                }
-
                 if (GUILayout.Button("Export Selected Directories", GUILayout.Height(30)))
                 {
                     string[] selectedDirs = _directoryItems
@@ -173,9 +181,7 @@ namespace SymphonyFrameWork.Editor
                     // 出力内容を確定してから提示し、確認ウィンドウの承認を受けて実行する。
                     AssetStoreToolsPackagePlan plan = CreatePlan(
                         selectedDirs,
-                        _packageMode,
-                        _createZip,
-                        _usedDependencies);
+                        _pipelines[_selectedPipelineIndex]);
 
                     if (plan != null)
                     {
@@ -183,6 +189,37 @@ namespace SymphonyFrameWork.Editor
                     }
                 }
             }
+        }
+
+        /// <summary>
+        ///     出力パイプラインの選択を描画する。
+        /// </summary>
+        /// <remarks>
+        ///     選択肢の表示名はアセット名。手順の内容は確認ウィンドウで提示する。
+        /// </remarks>
+        /// <returns> 選択できるパイプラインがあり、出力へ進める場合はtrue。 </returns>
+        private bool DrawPipelineSelection()
+        {
+            if (_pipelines.Count == 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "出力パイプラインがアサインされていません。\n"
+                    + "Project Settings > SymphonyFrameWork > Asset Store Tools Packager で"
+                    + "アサインしてください。",
+                    MessageType.Info);
+
+                if (GUILayout.Button("Open Project Settings", GUILayout.Width(180)))
+                {
+                    SettingsService.OpenProjectSettings(AssetStoreToolsPackagerProvider.SELF_PATH);
+                }
+
+                return false;
+            }
+
+            _selectedPipelineIndex = EditorGUILayout.Popup(
+                "Export Pipeline", _selectedPipelineIndex, _pipelineLabels);
+
+            return true;
         }
 
         /// <summary>
@@ -201,7 +238,7 @@ namespace SymphonyFrameWork.Editor
             {
                 EditorGUILayout.HelpBox(
                     "出力済みのパッケージがありません。\n"
-                    + "Export タブで Export Mode = Singles として出力してください。",
+                    + "Export タブで、Singles を含むパイプラインを選んで出力してください。",
                     MessageType.Info);
                 return;
             }
@@ -317,25 +354,26 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary>
-        ///     Combineが選択されている場合に、廃止予定であることを表示する。
+        ///     Project Settingsからパイプラインの一覧を読み直す。
         /// </summary>
         /// <remarks>
-        ///     選択自体は禁止しない。既存の運用を突然壊さず、移行期間を設けるため。
+        ///     参照が外れたままの要素は選択肢から除く。
+        ///     Project Settingsの配列はnullを持てるため。
         /// </remarks>
-        private void DrawCombineDeprecationHelp()
+        private void RefreshPipelines()
         {
-#pragma warning disable CS0618
-            if ((_packageMode & PackageModeEnum.Combine) == 0)
-            {
-                return;
-            }
-#pragma warning restore CS0618
+            _pipelines.Clear();
+            _pipelines.AddRange(
+                AssetStoreToolsPackagerData.Pipelines.Where(pipeline => pipeline != null));
 
-            EditorGUILayout.HelpBox(
-                "Combine は廃止予定です。Singles を使用してください。\n"
-                + "統合パッケージはディレクトリ単位で取り出せないため、差分インポートの対象になりません。"
-                + "Combine だけを指定した場合、PackageManifest.json は作られません。",
-                MessageType.Warning);
+            _pipelineLabels = _pipelines
+                .Select(pipeline => pipeline.name)
+                .ToArray();
+
+            if (_selectedPipelineIndex >= _pipelines.Count)
+            {
+                _selectedPipelineIndex = 0;
+            }
         }
 
         /// <summary>

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackager.cs
@@ -26,7 +26,14 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary> 個別または統合パッケージの出力形式を表すフラグ。 </summary>
+        /// <remarks>
+        ///     <see cref="Combine" />を除くと<see cref="Singles" />と<see cref="Nothing" />しか残らず、
+        ///     enumとして意味を失うため、次のメジャー更新でenumごと削除する。
+        /// </remarks>
         [Flags]
+        [Obsolete(
+            "パイプラインへ移行しました。" + nameof(AssetStoreToolsPackagePipeline) + "を使用してください。",
+            error: false)]
         public enum PackageModeEnum : byte
         {
             /// <summary> パッケージを出力しない無効な状態。 </summary>
@@ -111,13 +118,25 @@ namespace SymphonyFrameWork.Editor
         }
 
         /// <summary> 指定ディレクトリを選択された形式で出力し、必要に応じてZIP化する。 </summary>
+        /// <remarks>
+        ///     指定を等価な手順の並びへ変換してパイプラインへ委譲する。動作は3.5.0までと同じ。
+        /// </remarks>
         /// <param name="directories"> 出力対象のディレクトリ。 </param>
         /// <param name="mode"> 個別出力と統合出力の指定。 </param>
         /// <param name="createZip"> 出力後にZIP化するか。 </param>
         /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
+#pragma warning disable CS0618
+        [Obsolete(
+            "パイプラインへ移行しました。Export(string[], "
+            + nameof(AssetStoreToolsPackagePipeline) + ")を使用してください。",
+            error: false)]
         public static void Export(string[] directories, PackageModeEnum mode, bool createZip = false, bool usedDependencies = false)
         {
-            AssetStoreToolsPackagePlan plan = CreatePlan(directories, mode, createZip, usedDependencies);
+            AssetStoreToolsPackagePlan plan = AssetStoreToolsPackagePipelineRunner.CreatePlan(
+                directories,
+                CreateStepsFromOptions(mode, createZip, usedDependencies),
+                LEGACY_PIPELINE_NAME);
+
             if (plan == null)
             {
                 return;
@@ -125,6 +144,7 @@ namespace SymphonyFrameWork.Editor
 
             Export(plan);
         }
+#pragma warning restore CS0618
 
         /// <summary>
         ///     出力内容を確定した計画を組み立てる。この時点ではファイルを出力しない。
@@ -144,26 +164,6 @@ namespace SymphonyFrameWork.Editor
 
             return AssetStoreToolsPackagePipelineRunner.CreatePlan(
                 directories, pipeline.Steps, pipeline.name);
-        }
-
-        /// <summary>
-        ///     旧来のフラグ指定から計画を組み立てる。この時点ではファイルを出力しない。
-        /// </summary>
-        /// <param name="directories"> 出力対象のディレクトリ。 </param>
-        /// <param name="mode"> 個別出力と統合出力の指定。 </param>
-        /// <param name="createZip"> 出力後にZIP化するか。 </param>
-        /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
-        /// <returns> 出力計画。対象が無い場合や設定を読み込めない場合はnull。 </returns>
-        internal static AssetStoreToolsPackagePlan CreatePlan(
-            string[] directories,
-            PackageModeEnum mode,
-            bool createZip,
-            bool usedDependencies)
-        {
-            return AssetStoreToolsPackagePipelineRunner.CreatePlan(
-                directories,
-                CreateStepsFromOptions(mode, createZip, usedDependencies),
-                LEGACY_PIPELINE_NAME);
         }
 
         /// <summary>
@@ -221,6 +221,9 @@ namespace SymphonyFrameWork.Editor
         /// <param name="createZip"> 出力後にZIP化するか。 </param>
         /// <param name="usedDependencies"> 使用中アセットと強制包含拡張子だけへ絞るか。 </param>
         /// <returns> 指定に対応する手順の並び。 </returns>
+        // 非推奨のPackageModeEnumは削除まで動作を維持する必要があるため、
+        // 廃止予定の警告をここでは抑止する。利用側の指定に対しては警告が出る。
+#pragma warning disable CS0618
         private static List<AssetStoreToolsPackageStepStrategy> CreateStepsFromOptions(
             PackageModeEnum mode,
             bool createZip,
@@ -238,14 +241,10 @@ namespace SymphonyFrameWork.Editor
                 steps.Add(new AssetStoreToolsSinglePackageStrategy());
             }
 
-            // 非推奨のCombineは削除まで動作を維持する必要があるため、
-            // 廃止予定の警告をここでは抑止する。利用側の指定に対しては警告が出る。
-#pragma warning disable CS0618
             if ((mode & PackageModeEnum.Combine) != 0)
             {
                 steps.Add(new AssetStoreToolsCombinePackageStrategy());
             }
-#pragma warning restore CS0618
 
             if (createZip)
             {
@@ -254,5 +253,6 @@ namespace SymphonyFrameWork.Editor
 
             return steps;
         }
+#pragma warning restore CS0618
     }
 }

--- a/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagerData.cs
+++ b/Editor/Generator/AssetStoreToolsPackager/AssetStoreToolsPackagerData.cs
@@ -1,4 +1,6 @@
 ﻿using SymphonyFrameWork.Core;
+using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 namespace SymphonyFrameWork.Editor
@@ -14,6 +16,34 @@ namespace SymphonyFrameWork.Editor
 
         /// <summary> 生成したパッケージを保存するフォルダのパス。 </summary>
         public static string ExportedPackagesPath => instance.exportedPackagesPath;
+
+        /// <summary>
+        ///     Packagerウィンドウで選べる出力パイプライン。
+        /// </summary>
+        /// <remarks>
+        ///     アサインされていない場合は空。要素にnullが含まれることがある。
+        ///     Project Settingsの配列で参照を外したままにできるため。
+        /// </remarks>
+        public static IReadOnlyList<AssetStoreToolsPackagePipeline> Pipelines => instance._pipelines;
+
+        /// <summary> 出力パイプラインの一覧を保存する。 </summary>
+        /// <param name="pipelines"> 保存する一覧。nullの場合は空として扱う。 </param>
+        public static void SetPipelines(IReadOnlyList<AssetStoreToolsPackagePipeline> pipelines)
+        {
+            AssetStoreToolsPackagePipeline[] values = pipelines == null
+                ? Array.Empty<AssetStoreToolsPackagePipeline>()
+                : new AssetStoreToolsPackagePipeline[pipelines.Count];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = pipelines[i];
+            }
+
+            instance._pipelines = values;
+            EditorUtility.SetDirty(instance);
+            AssetDatabase.SaveAssets();
+            Save();
+        }
 
         /// <summary> パッケージ対象フォルダのパスを保存する。 </summary>
         public static void SetAssetStoreToolsPath(string path)
@@ -43,6 +73,9 @@ namespace SymphonyFrameWork.Editor
 
         [SerializeField, Tooltip("パッケージ対象となるAsset Store Toolsフォルダのパス。")]
         private string _assetStoreToolsPath = EditorSymphonyConstant.ASSET_STORE_TOOLS_PATH;
+
+        [SerializeField, Tooltip("Packagerウィンドウで選べる出力パイプライン。")]
+        private AssetStoreToolsPackagePipeline[] _pipelines = Array.Empty<AssetStoreToolsPackagePipeline>();
 
         /// <summary> 現在の設定値をProjectSettingsへ保存する。 </summary>
         private static void Save() => instance.Save(true);

--- a/Editor/SettingProvider/AssetStoreToolsPackagerProvider.cs
+++ b/Editor/SettingProvider/AssetStoreToolsPackagerProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using SymphonyFrameWork.Core;
+using System.Collections.Generic;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -32,7 +34,7 @@ namespace SymphonyFrameWork.Editor.SettingProvider
                 // 検索するときのキーワード
                 keywords = new HashSet<string>(new[]
                 {
-                    "asset", "store", "tools", "packager", "ignore", "extension"
+                    "asset", "store", "tools", "packager", "ignore", "extension", "pipeline"
                 }),
             };
 
@@ -68,7 +70,131 @@ namespace SymphonyFrameWork.Editor.SettingProvider
             }
 
             EditorGUILayout.Space();
+            DrawPipelines();
+
+            EditorGUILayout.Space();
             DrawConfig();
+        }
+
+        /// <summary>
+        ///     Packagerウィンドウで選べる出力パイプラインの一覧を描画する。
+        /// </summary>
+        /// <remarks>
+        ///     ProjectSettingsへ保存する設定のため、パスの項目と同じく変更した時点で保存する。
+        ///     PackagerConfig.jsonのようなSave／Reloadは設けない。
+        /// </remarks>
+        private static void DrawPipelines()
+        {
+            EditorGUILayout.LabelField("Export Pipelines", EditorStyles.boldLabel);
+
+            List<AssetStoreToolsPackagePipeline> pipelines =
+                new(AssetStoreToolsPackagerData.Pipelines);
+
+            bool isChanged = false;
+            int removeIndex = -1;
+
+            using (new EditorGUI.IndentLevelScope())
+            {
+                for (int i = 0; i < pipelines.Count; i++)
+                {
+                    EditorGUILayout.BeginHorizontal();
+
+                    var edited = (AssetStoreToolsPackagePipeline)EditorGUILayout.ObjectField(
+                        pipelines[i], typeof(AssetStoreToolsPackagePipeline), false);
+                    if (edited != pipelines[i])
+                    {
+                        pipelines[i] = edited;
+                        isChanged = true;
+                    }
+
+                    if (GUILayout.Button("-", GUILayout.Width(24)))
+                    {
+                        removeIndex = i;
+                    }
+
+                    EditorGUILayout.EndHorizontal();
+                }
+
+                if (removeIndex >= 0)
+                {
+                    pipelines.RemoveAt(removeIndex);
+                    isChanged = true;
+                }
+
+                EditorGUILayout.BeginHorizontal();
+                if (GUILayout.Button("Add", GUILayout.Width(100)))
+                {
+                    pipelines.Add(null);
+                    isChanged = true;
+                }
+
+                if (GUILayout.Button("Create Default Pipeline", GUILayout.Width(180)))
+                {
+                    AssetStoreToolsPackagePipeline created = CreateDefaultPipelineAsset();
+                    if (created != null)
+                    {
+                        pipelines.Add(created);
+                        isChanged = true;
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (isChanged)
+            {
+                AssetStoreToolsPackagerData.SetPipelines(pipelines);
+            }
+
+            if (pipelines.Count == 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "出力パイプラインがアサインされていません。"
+                    + "Create Default Pipeline を押すと、Singles → Used Dependencies → Create ZIP の"
+                    + "テンプレートを生成してアサインします。",
+                    MessageType.Info);
+            }
+        }
+
+        /// <summary>
+        ///     既定テンプレートのパイプラインアセットを生成する。
+        /// </summary>
+        /// <remarks>
+        ///     Frameworkの起動時に自動生成しない。利用側のリポジトリへ意図しないアセットを増やさないため、
+        ///     このボタンの明示的な操作でだけ生成する。
+        /// </remarks>
+        /// <returns> 生成したアセット。生成に失敗した場合はnull。 </returns>
+        private static AssetStoreToolsPackagePipeline CreateDefaultPipelineAsset()
+        {
+            string directory = EditorSymphonyConstant.RESOURCES_EDITOR_PATH;
+
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (IOException exception)
+            {
+                Debug.LogError(
+                    $"[{nameof(AssetStoreToolsPackagerProvider)}]\n"
+                    + $"パイプラインの配置先を生成できませんでした: {directory}\n{exception.Message}");
+                return null;
+            }
+
+            AssetDatabase.Refresh();
+
+            // 同名のアセットがある場合は上書きせず別名で作る。
+            // 利用側が手を入れたパイプラインを、ボタンの誤操作で失わせないため。
+            string path = AssetDatabase.GenerateUniqueAssetPath(
+                directory + "/" + nameof(AssetStoreToolsPackagePipeline) + ".asset");
+
+            AssetStoreToolsPackagePipeline pipeline = AssetStoreToolsPackagePipeline.CreateTemplate();
+            AssetDatabase.CreateAsset(pipeline, path);
+            AssetDatabase.SaveAssets();
+
+            Debug.Log(
+                $"[{nameof(AssetStoreToolsPackagerProvider)}]\n"
+                + $"既定のパイプラインを生成しました: {path}");
+
+            return pipeline;
         }
 
         /// <summary> パッケージ化設定ファイルの内容を描画する。 </summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphonyframework",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "displayName": "Symphony Framework",
   "description": "This is Symphony Framework",
   "unity": "6000.0",


### PR DESCRIPTION
Issue: #124

Asset Store Tools Packager のパイプライン化 **Round 2（設定とUI）** です。Round 1（3.6.0、PR #139）で追加した基盤を、ウィンドウと Project Settings から使えるようにします。

設計書: `Documentation/Designs/AssetStoreToolsPackagePipeline.md`（ワークスペース側）

## この Round の範囲

- `AssetStoreToolsPackagerData` へ `_pipelines` を追加し、Project Settings で配列としてアサインできるようにした
- `Create Default Pipeline` ボタンで、`Singles → Used Dependencies → Create ZIP` のテンプレートを `Assets/Editor/SymphonyFrameWork/Configs/` へ生成
- Packager ウィンドウの `Export Mode` をパイプラインのポップアップ `Export Pipeline` へ差し替え、`Create ZIP File` / `Used Dependencies` のトグルを削除
- `PackageModeEnum` と `Export(string[], PackageModeEnum, bool, bool)` を `[Obsolete]` 化（警告のみ。動作は不変）
- `Documentation~/EditorTools.md` と `Documentation~/Deprecations.md` を更新

**破壊的変更はありません。** 既存の呼び出しはコンパイル警告が出るだけで動きます。ウィンドウを使っている場合だけ、初回に `Create Default Pipeline` を1度押す必要があります。

## Combine

**統合パッケージ出力は機能として残ります。** 非推奨にしたのは enum の選択肢であって、統合パッケージそのものではありません。`AssetStoreToolsCombinePackageStrategy` に `[Obsolete]` は付けておらず、サブクラスセレクターの候補には出ます。差分インポートの単位にならないため既定テンプレートには含めていません。

## 実装時の追加判断

- `internal CreatePlan(string[], PackageModeEnum, bool, bool)` を削除しました。ウィンドウがパイプラインへ移った時点で唯一の呼び出し元が非推奨の公開 `Export` だけになったためインライン展開しています。`internal` なのでバージョニング上の制約はありません。
- **Export タブへ切り替えたときにパイプラインの一覧を読み直します。** Project Settings の配列は、Packager ウィンドウを開いたまま変更され得るためです。Import タブが既に同じ形だったのに揃えました。`OnEnable` と `Refresh` ボタンだけでは反映されないことを実測で確認しています。

## 検証

- `uloop-compile`: エラー0 / `Assets/SymphonyFrameWork/` 由来の警告0
- EditMode テスト: 282件全数成功 / Failed 0 / Skipped 0 / `Success=true`。2回連続
- **Editor 上での実機確認**
  - パイプラインアセットの `[SerializeReference]` が型情報つきで永続化されること
  - `AssetStoreToolsPackagerData.asset` へ `_pipelines: - {fileID: 11400000, guid: ..., type: 2}` と guid 参照が書かれること
  - Export タブに `Export Pipeline` ポップアップが出て、アセット名が選択肢になること（スクリーンショットで確認）
  - Project Settings に `Export Pipelines` と `Create Default Pipeline` が出ること（同上）
  - パイプラインが空のとき、案内の HelpBox と `Open Project Settings` だけが出て Export ボタンが消えること（同上）
- **人手でのボタン操作が必要な確認**: `Create Default Pipeline` と `Export Selected Directories` のクリック。EditorWindow のコントロールは自動で叩けないため、生成処理と出力処理は同等のコード経路を通して確認しています。
